### PR TITLE
Bugfix handling if version information is None

### DIFF
--- a/miflora/miflora_poller.py
+++ b/miflora/miflora_poller.py
@@ -173,7 +173,14 @@ class MiFloraPoller(object):
         return ''.join(chr(n) for n in name)
 
     def fill_cache(self):
-        if self.firmware_version() >= "2.6.6":
+        firmware_version = self.firmware_version()
+        if not firmware_version:
+            # If a sensor doesn't work, wait 5 minutes before retrying
+            self._last_read = datetime.now() - self._cache_timeout + \
+                timedelta(seconds=300)
+            return
+
+        if firmware_version >= "2.6.6":
             write_ble(self._mac, "0x33", "A01F")
         self._cache = read_ble(self._mac,
                                "0x35",


### PR DESCRIPTION
The error handling when the version information is None is buggy. This is a quick fix, because a lot of home-assistant users complained ([#4868](https://github.com/home-assistant/home-assistant/issues/4868), [#4479](https://github.com/home-assistant/home-assistant/issues/4479)). The latest commit https://github.com/open-homeautomation/miflora/commit/db9a32cbdaad584deed0575feda5e75c75de3786 was intended to fix this but failed.