### PR TITLE
Implementation of historical data retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ target/
 .DS_Store
 .project
 .pydevproject
+/venv/
+/.idea/

--- a/demo.py
+++ b/demo.py
@@ -1,19 +1,18 @@
 import argparse
-from miflora.miflora_poller import MiFloraPoller, \
-    MI_CONDUCTIVITY, MI_MOISTURE, MI_LIGHT, MI_TEMPERATURE, MI_BATTERY
-
+from miflora.miflora_poller import MiFloraPoller
 
 parser = argparse.ArgumentParser()
 parser.add_argument('mac')
 args = parser.parse_args()
 
-poller = MiFloraPoller(args.mac)
-print("Getting data from Mi Flora")
-print("FW: {}".format(poller.firmware_version()))
-print("Name: {}".format(poller.name()))
-print("Temperature: {}".format(poller.parameter_value(MI_TEMPERATURE)))
-print("Moisture: {}".format(poller.parameter_value(MI_MOISTURE)))
-print("Light: {}".format(poller.parameter_value(MI_LIGHT)))
-print("Conductivity: {}".format(poller.parameter_value(MI_CONDUCTIVITY)))
-print("Battery: {}".format(poller.parameter_value(MI_BATTERY)))
+device = MiFloraPoller(args.mac)
 
+with device:
+    print("Getting data from Mi Flora")
+    print("FW: {}".format(device.firmware_version))
+    print("Name: {}".format(device.name))
+    print("Temperature: {}".format(device.temperature))
+    print("Moisture: {}".format(device.moisture))
+    print("Light: {}".format(device.light))
+    print("Conductivity: {}".format(device.conductivity))
+    print("Battery: {}".format(device.battery_level))

--- a/demo.py
+++ b/demo.py
@@ -1,11 +1,17 @@
+import argparse
 from miflora.miflora_poller import MiFloraPoller, \
     MI_CONDUCTIVITY, MI_MOISTURE, MI_LIGHT, MI_TEMPERATURE, MI_BATTERY
 
-poller = MiFloraPoller("C4:7C:8D:60:8F:E6")
+
+parser = argparse.ArgumentParser()
+parser.add_argument('mac')
+args = parser.parse_args()
+
+poller = MiFloraPoller(args.mac)
 print("Getting data from Mi Flora")
 print("FW: {}".format(poller.firmware_version()))
 print("Name: {}".format(poller.name()))
-print("Temperature: {}".format(poller.parameter_value("temperature")))
+print("Temperature: {}".format(poller.parameter_value(MI_TEMPERATURE)))
 print("Moisture: {}".format(poller.parameter_value(MI_MOISTURE)))
 print("Light: {}".format(poller.parameter_value(MI_LIGHT)))
 print("Conductivity: {}".format(poller.parameter_value(MI_CONDUCTIVITY)))

--- a/logging_demo.py
+++ b/logging_demo.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import pandas as pd
+import argparse
+import logging
+from miflora.miflora_poller import MiFloraPoller
+
+logger = logging.getLogger(__name__)
+logger.level = logging.DEBUG
+stream_handler = logging.StreamHandler(sys.stdout)
+logger.addHandler(stream_handler)
+
+parser = argparse.ArgumentParser()
+parser.add_argument('mac')
+parser.add_argument('data_file', default=None, nargs="?")
+args = parser.parse_args()
+
+device = MiFloraPoller(args.mac)
+
+with device:
+    # Fetch history data from device
+    data = device.history
+
+    # Take a measurement from the device
+    # data = [device.measurement]
+
+data = pd.DataFrame(data)
+logger.info(data)
+
+# Save as csv
+if args.data_file is not None and data.empty is False:
+    if os.path.exists(args.data_file):
+        with open(args.data_file, 'a') as f:
+            data.to_csv(f, header=False, index=False)
+    else:
+        with open(args.data_file, 'w') as f:
+            data.to_csv(f, header=True, index=False)

--- a/miflora/decorators.py
+++ b/miflora/decorators.py
@@ -1,0 +1,74 @@
+import time
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+def retry(retries=3, exception=Exception, delay=None, on_exception=None):
+    """
+    Retry decorator
+    :param retries: number of retries to perform
+    :param exception: Exception, or tuple thereof, to catch
+    :param delay: function returning sleeping time [s] between tries
+    :param on_exception: callback executed on exception
+    :return:
+    """
+    def _decorator(func):
+        def _wrapper(*args, **kwargs):
+            ex = None
+            for i in range(retries+1):
+                try:
+                    return func(*args, **kwargs)
+                except exception as e:
+                    ex = e
+                    if on_exception is not None:
+                        on_exception(e)
+                if delay is not None:
+                    time.sleep(delay(i))
+            else:
+                raise ex
+        return _wrapper
+    return _decorator
+
+
+def auto_connect(func):
+    """
+    Automatic connection decorator
+    Ensures that a connection is established if it is not already done
+    """
+    def _wrapper(self, *args, **kwargs):
+        if not self.connected:
+            with self:
+                return func(self, *args, **kwargs)
+        else:
+            return func(self, *args, **kwargs)
+    return _wrapper
+
+
+def cached_ttl(ttl):
+    """
+    Simple timed cache decorator implementation
+    Keeps track of time and caller arguments
+    :param ttl: cache time to live [s]
+    :return:
+    """
+    def _decorator(func):
+        cache = None
+        timestamp = 0
+        function_args = None
+
+        def _wrapper(*args, **kwargs):
+            nonlocal timestamp
+            nonlocal function_args
+            nonlocal cache
+            now = time.time()
+            if cache is not None and (now - timestamp) < ttl and function_args == (args, kwargs):
+                LOGGER.debug("Cache returned for %s" % func)
+                return cache
+            else:
+                timestamp = now
+                function_args = (args, kwargs)
+                cache = func(*args, **kwargs)
+                return cache
+        return _wrapper
+    return _decorator

--- a/miflora/miflora_poller.py
+++ b/miflora/miflora_poller.py
@@ -112,6 +112,11 @@ class MiFloraPoller:
         return self._fetch_measurement()
 
     @property
+    def history(self):
+        """Fetch and return current device history"""
+        return self._fetch_history()
+
+    @property
     def temperature(self):
         """Return temperature measurement"""
         return self._fetch_measurement()[MI_TEMPERATURE]
@@ -161,9 +166,12 @@ class MiFloraPoller:
         if self.firmware_version >= "2.6.6":
             self.write(handle_measurement_control, cmd_measurement_read_init, withResponse=True)
         response = self.read(handle_measurement_read)
+
         if response == INVALID_DATA:
             raise ValueError('Received invalid data from the sensor')
+
         timestamps = self._fetch_device_time()
+        timestamps[MI_WALL_TIME] = datetime.fromtimestamp(timestamps[MI_WALL_TIME])
         return {**timestamps, **self._decode_measurement(response)}
 
     @auto_connect

--- a/miflora/miflora_poller.py
+++ b/miflora/miflora_poller.py
@@ -52,8 +52,8 @@ class MiFloraPoller(object):
         """
         Return the name of the sensor.
         """
-        # TODO: implement me
-        return "no name"
+        byte_array = self._retry(self.peripheral.readCharacteristic, [0x03])
+        return byte_array.decode('ascii')
 
     def fill_cache(self):
         firmware_version = self.firmware_version()

--- a/miflora/miflora_poller.py
+++ b/miflora/miflora_poller.py
@@ -5,196 +5,277 @@ Reading from the sensor is handled by the command line tool "gatttool" that
 is part of bluez on Linux.
 No other operating systems are supported at the moment
 """
-
-from datetime import datetime, timedelta
 import logging
 import time
 import threading
+from datetime import datetime
 from bluepy.btle import Peripheral, BTLEException, ADDR_TYPE_PUBLIC
+from miflora.decorators import retry, auto_connect, cached_ttl
+
+LOGGER = logging.getLogger(__name__)
 
 MI_TEMPERATURE = "temperature"
 MI_LIGHT = "light"
 MI_MOISTURE = "moisture"
 MI_CONDUCTIVITY = "conductivity"
 MI_BATTERY = "battery"
+MI_FIRMWARE = "firmware"
+MI_DEVICE_TIME = "device_time"
+MI_WALL_TIME = "wall_time"
 
 BYTEORDER = 'little'
 INVALID_DATA = b'\xaa\xbb\xcc\xdd\xee\xff\x99\x88wf\x00\x00\x00\x00\x00\x00'
 
-"""Configure how long data is cached before new values are
-retrieved from the sensor.
-"""
+handle_device_name = 0x03
+handle_device_info = 0x38
+handle_device_time = 0x41
+handle_measurement_control = 0x33
+handle_measurement_read = 0x35
+handle_history_control = 0x3e
+handle_history_read = 0x3c
 
-LOGGER = logging.getLogger(__name__)
+cmd_measurement_read_init = b'\xa0\x00'
+cmd_history_read_init = b'\xa0\x00\x00'
+cmd_history_read_success = b'\xa2\x00\x00'
+cmd_history_read_failed = b'\xa3\x00\x00'
 
 
-class MiFloraPoller(object):
+def cmd_history_address(addr):
+    return b'\xa1' + addr.to_bytes(2, BYTEORDER)
+
+
+class MiFlowerCareException(Exception):
+    pass
+
+
+class MiFloraPoller:
     """"
     A class to read data from Mi Flora plant sensors.
     """
 
-    # Lock for access to the bluetooth device,
-    # Class member, so there can only be one class instance accessing bluetooth
-    _GLOBAL_LOCK = threading.Lock()
-
-    def __init__(self, mac, cache_timeout=600, retries=3, sleep_time=0.5, adapter='0'):
+    def __init__(self,
+                 mac,
+                 device_info_cache_ttl=3600,
+                 measurement_cache_ttl=10,
+                 retries=3,
+                 retry_delay=lambda x: 2**(x*0.5),
+                 iface=0,
+                 firmware_version=None):
         """
         Initialize a Mi Flora Poller for the given MAC address.
 
         Arguments:
             mac (string): MAC address of the sensor to be polled
-            cache_timeout (int): Maximum age of the sensor data before it will be polled again
+            device_info_cache_ttl (int): Maximum age of the device info data before it will be polled again
+            measurement_cache_ttl (int): Maximum age of the measurement data before it will be polled again
             retries (int): number of retries for errors in the Bluetooth communication
-            sleep_time (float): base factor of time between retries. with every retry,
-                the factor is squared (=expotential backoff time)
-            adapter (int): number of the Bluetooth adapter to be used, "0" means "/dev/hci0"
+            retry_delay (fn): delay function returning seconds of delay dependent on retry number
+            iface (int): number of the Bluetooth adapter to be used, 0 means "/dev/hci0"
 
         """
         self._mac = mac
-        self._adapter = adapter
-        self._cache_timeout = timedelta(seconds=cache_timeout)
-        self._sleep_time = sleep_time
-        self._last_read = None
-        self._retries = retries
-        self._firmware_version = None
-        self._battery = None
-        self._name = None
-        self._temperature = None
-        self._brightness = None
-        self._moisture = None
-        self._conductivity = None
+        self._iface = iface
         self._lock = threading.Lock()
+        self._peripheral = Peripheral()
+        self._firmware_version = firmware_version
 
+        # Decorate
+        retry_fcn = retry(retries, BTLEException, retry_delay, self.reconnect_on_disconnect)
+        self.read = retry_fcn(self._peripheral.readCharacteristic)
+        self.write = retry_fcn(self._peripheral.writeCharacteristic)
+        self._fetch_device_info = cached_ttl(device_info_cache_ttl)(self._fetch_device_info)
+        self._fetch_measurement = cached_ttl(measurement_cache_ttl)(self._fetch_measurement)
+        self._fetch_name = cached_ttl(device_info_cache_ttl)(self._fetch_name)
+
+    @property
     def battery_level(self):
         """Return the battery level."""
-        self._fill_cache()
-        return self._battery
+        return self._fetch_device_info()[MI_BATTERY]
 
+    @property
     def firmware_version(self):
         """ Return the firmware version. """
-        self._fill_cache()
-        return self._firmware_version
+        # Overwrite firmware version if fixed to reduce ble reads
+        if self._firmware_version is not None:
+            return self._firmware_version
+        else:
+            return self._fetch_device_info()[MI_FIRMWARE]
 
+    @property
     def name(self):
         """Return the name of the sensor."""
-        self._fill_cache()
-        return self._name
+        return self._fetch_name()
 
-    def parameter_value(self, parameter, read_cached=True):
-        """
-        Return a value of one of the monitored paramaters.
+    @property
+    def measurement(self):
+        """Return measurement dict"""
+        return self._fetch_measurement()
 
-        This method will try to retrieve the data from cache and only
-        request it by bluetooth if no cached value is stored or the cache is
-        expired.
-        This behaviour can be overwritten by the "read_cached" parameter.
-        """
-        self._fill_cache(read_cached)
-        if parameter == MI_BATTERY:
-            return self.battery_level()
-        elif parameter == MI_CONDUCTIVITY:
-            return self._conductivity
-        elif parameter == MI_MOISTURE:
-            return self._moisture
-        elif parameter == MI_TEMPERATURE:
-            return self._temperature
-        elif parameter == MI_LIGHT:
-            return self._brightness
-        raise Exception('unknown parameter %s', parameter)
+    @property
+    def temperature(self):
+        """Return temperature measurement"""
+        return self._fetch_measurement()[MI_TEMPERATURE]
 
-    def _fill_cache(self, read_cached=True):
-        """Fetch new data from the sensor.
+    @property
+    def light(self):
+        """Return brightness measurement"""
+        return self._fetch_measurement()[MI_LIGHT]
 
-        This will only update the data if:
-        - there are no previous measurements or
-        - read_cached is False or
-        - the measurements are older than 5 minutes
+    @property
+    def moisture(self):
+        """Return moisture measurement"""
+        return self._fetch_measurement()[MI_MOISTURE]
 
-        This method is tread safe: There can only be one object per
-        Python Runtime that is accessing the bluetooth sensor.
-        """
+    @property
+    def conductivity(self):
+        """Return conductivity measurement"""
+        return self._fetch_measurement()[MI_CONDUCTIVITY]
 
-        # get local lock so that we do not poll data while an update is in progress
-        # this lock is only for the current sensor. So you still can get cached data
-        # while the update of another sensor is in progress.
-        with self._lock:
+    @auto_connect
+    def _fetch_device_info(self):
+        """Fetch device battery and firmware info"""
+        response = self.read(handle_device_info)
+        return self._decode_device_info(response)
 
-            if self._last_read is None or \
-                    (self._last_read + self._cache_timeout) <= datetime.now() or \
-                    not read_cached:
-                # get global lock when accessing the Bluetooth hardware
-                # this lock is only aquired if we acutally read data from the hardware
-                # this will make sure that only one process is using the Bluetooth
-                # communication at a time.
-                with MiFloraPoller._GLOBAL_LOCK:
-                    peripheral = self._retry(Peripheral, [self._mac, ADDR_TYPE_PUBLIC, self._adapter])
-                    LOGGER.debug('connected to device %s', self._mac)
+    @auto_connect
+    def _fetch_device_time(self):
+        """Fetch device time"""
+        start = time.time()
+        response = self.read(handle_device_time)
+        ts = (time.time() + start) / 2
 
-                    self._fetch_name(peripheral)
-                    self._fetch_version_battery(peripheral)
-                    self._fetch_measurements(peripheral)
-                    peripheral.disconnect()
-                    self._last_read = datetime.now()
+        return {
+            MI_DEVICE_TIME: int.from_bytes(response, BYTEORDER),
+            MI_WALL_TIME: ts
+        }
 
-    def _fetch_name(self, peripheral):
+    @auto_connect
+    def _fetch_name(self):
         """Fetch the name of the sensor."""
-        byte_array = self._retry(peripheral.readCharacteristic, [0x03])
-        self._name = byte_array.decode('ascii')
+        response = self.read(handle_device_name)
+        return response.decode('ascii')
 
-    def _fetch_version_battery(self, peripheral):
-        """Fetch the version number and battery level from the sensor."""
-        result = self._retry(peripheral.readCharacteristic, [0x38])
-        self._decode_characteristic_38(result)
-
-    def _fetch_measurements(self, peripheral):
+    @auto_connect
+    def _fetch_measurement(self):
         """Fetch the measurements from the sensor."""
-        if self._firmware_version >= "2.6.6":
-            self._retry(peripheral.writeCharacteristic, [0x33, bytes([0xA0, 0x1F]), True])
-        result = self._retry(peripheral.readCharacteristic, [0x35])
-        if result == INVALID_DATA:
-            raise Exception('Received invalid data from the sensor')
-        self._decode_characteristic_35(result)
+        if self.firmware_version >= "2.6.6":
+            self.write(handle_measurement_control, cmd_measurement_read_init, withResponse=True)
+        response = self.read(handle_measurement_read)
+        if response == INVALID_DATA:
+            raise ValueError('Received invalid data from the sensor')
+        timestamps = self._fetch_device_time()
+        return {**timestamps, **self._decode_measurement(response)}
 
-    def _decode_characteristic_38(self, byte_array):
-        """Perform byte magic when decoding the data from the sensor."""
-        self._battery = int.from_bytes(byte_array[0:1], byteorder=BYTEORDER)
-        self._firmware_version = byte_array[2:7].decode('ascii')
+    @auto_connect
+    def _fetch_history(self):
+        """Fetch the historical measurements from the sensor. Only tested on firmware 2.9.2"""
+        self.write(handle_history_control, cmd_history_read_init, withResponse=True)
+        history_info = self.read(handle_history_read)
+
+        history_length = int.from_bytes(history_info[0:2], BYTEORDER)
+        if history_length > 0:
+            LOGGER.info("Getting %d measurements" % history_length)
+            data = []
+            for i in range(history_length):
+                payload = cmd_history_address(i)
+                try:
+                    self.write(handle_history_control, payload, withResponse=True)
+                    response = self.read(handle_history_read)
+                    if response != (0).to_bytes(16, BYTEORDER):  # Not invalid
+                        LOGGER.debug("History item retrieved")
+                        data.append(self._decode_history(response))
+                except BTLEException:
+                    LOGGER.debug("History read failed")
+                    self.write(handle_history_control, cmd_history_read_failed)
+
+                LOGGER.info("%.0f%%" % (100 * (i + 1) / history_length))
+            self.write(handle_history_control, cmd_history_read_success, withResponse=True)
+
+            _time = self._fetch_device_time()
+            time_diff = _time[MI_WALL_TIME] - _time[MI_DEVICE_TIME]
+            for entry in data:
+                entry[MI_WALL_TIME] = datetime.fromtimestamp(entry[MI_DEVICE_TIME] + time_diff)
+
+            return data
+
+    def _decode_device_info(self, byte_array):
+        """Perform byte magic when decoding the device info."""
+        data = {
+            MI_BATTERY: int.from_bytes(byte_array[0:1], BYTEORDER),
+            MI_FIRMWARE: byte_array[2:7].decode('ascii')
+        }
         LOGGER.debug('Raw data for char 0x38: %s', self._format_bytes(byte_array))
-        LOGGER.debug('battery: %d', self._battery)
-        LOGGER.debug('version: %s', self._firmware_version)
+        LOGGER.debug('battery: %d', data[MI_BATTERY])
+        LOGGER.debug('version: %s', data[MI_FIRMWARE])
+        return data
 
-    def _decode_characteristic_35(self, result):
-        """Perform byte magic when decoding the data from the sensor."""
+    def _decode_measurement(self, byte_array):
+        """Perform byte magic when decoding measurements."""
         # negative numbers are stored in one's complement
-        temp_bytes = result[0:2]
+        temp_bytes = byte_array[0:2]
         if temp_bytes[1] & 0x80 > 0:
             temp_bytes = [temp_bytes[0] ^ 0xFF, temp_bytes[1] ^ 0xFF]
 
-        # the temperature needs to be scaled by factor of 0.1
-        self._temperature = int.from_bytes(temp_bytes, byteorder=BYTEORDER)/10.0
-        self._brightness = int.from_bytes(result[3:5], byteorder=BYTEORDER)
-        self._moisture = int.from_bytes(result[7:8], byteorder=BYTEORDER)
-        self._conductivity = int.from_bytes(result[8:10], byteorder=BYTEORDER)
+        data = {
+            MI_TEMPERATURE: int.from_bytes(temp_bytes, BYTEORDER)/10.0,
+            MI_LIGHT: int.from_bytes(byte_array[3:5], BYTEORDER),
+            MI_MOISTURE: int.from_bytes(byte_array[7:8], BYTEORDER),
+            MI_CONDUCTIVITY: int.from_bytes(byte_array[8:10], BYTEORDER)
+        }
+        LOGGER.debug('Raw data for char 0x35: %s', self._format_bytes(byte_array))
+        LOGGER.debug('temp: %f', data[MI_TEMPERATURE])
+        LOGGER.debug('brightness: %d', data[MI_LIGHT])
+        LOGGER.debug('conductivity: %d', data[MI_CONDUCTIVITY])
+        LOGGER.debug('moisture: %d', data[MI_MOISTURE])
+        return data
 
-        LOGGER.debug('Raw data for char 0x35: %s', self._format_bytes(result))
-        LOGGER.debug('temp: %f', self._temperature)
-        LOGGER.debug('brightness: %d', self._brightness)
-        LOGGER.debug('conductivity: %d', self._conductivity)
-        LOGGER.debug('moisture: %d', self._moisture)
+    def _decode_history(self, byte_array):
+        """Perform byte magic when decoding history data."""
+        # negative numbers are stored in one's complement
+        temp_bytes = byte_array[4:6]
+        if temp_bytes[1] & 0x80 > 0:
+            temp_bytes = [temp_bytes[0] ^ 0xFF, temp_bytes[1] ^ 0xFF]
 
-    def _retry(self, func, args):
-        """Retry calling a function on Exception."""
-        for i in range(0, self._retries):
-            try:
-                return func(*args)
-            except BTLEException as exception:
-                LOGGER.info("function %s failed (try %d of %d)", func, i+1, self._retries)
-                time.sleep(self._sleep_time * (2 ^ i))
-                if i == self._retries - 1:
-                    LOGGER.error('retry finally failed!')
-                    raise exception
-                else:
-                    continue
+        data = {
+            MI_DEVICE_TIME: int.from_bytes(byte_array[:4], BYTEORDER),
+            MI_TEMPERATURE: int.from_bytes(temp_bytes, BYTEORDER)/10.0,
+            MI_LIGHT: int.from_bytes(byte_array[7:10], BYTEORDER),
+            MI_MOISTURE: byte_array[11],
+            MI_CONDUCTIVITY: int.from_bytes(byte_array[12:14], BYTEORDER)
+        }
+        LOGGER.debug('Raw data for char 0x3c: %s', self._format_bytes(byte_array))
+        LOGGER.debug('device time: %d', data[MI_DEVICE_TIME])
+        LOGGER.debug('temp: %f', data[MI_TEMPERATURE])
+        LOGGER.debug('brightness: %d', data[MI_LIGHT])
+        LOGGER.debug('conductivity: %d', data[MI_CONDUCTIVITY])
+        LOGGER.debug('moisture: %d', data[MI_MOISTURE])
+        return data
+
+    @property
+    def connected(self):
+        """Check if device is believed to be connected."""
+        return True if self._peripheral._helper is not None else False
+
+    def _connect(self):
+        """Connect self._peripheral to the device."""
+        self._peripheral.connect(self._mac, ADDR_TYPE_PUBLIC, iface=self._iface)
+
+    def reconnect_on_disconnect(self, exception: BTLEException):
+        """Callback for reconnecting after an untimely disconnect
+        (the device stops the connection after approximately 3 sec)."""
+        assert type(exception) is BTLEException
+        if exception.code == BTLEException.DISCONNECTED:
+            LOGGER.debug("reconnecting after retry")
+            self._connect()
+
+    def __enter__(self):
+        self._lock.acquire()
+        self._connect()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._peripheral.__exit__(exc_type, exc_val, exc_tb)
+        self._lock.release()
 
     @staticmethod
     def _format_bytes(raw_data):

--- a/miflora/miflora_poller.py
+++ b/miflora/miflora_poller.py
@@ -52,6 +52,7 @@ class MiFloraPoller(object):
         """
         Return the name of the sensor.
         """
+        self._connect()
         byte_array = self._retry(self.peripheral.readCharacteristic, [0x03])
         return byte_array.decode('ascii')
 

--- a/miflora/miflora_poller.py
+++ b/miflora/miflora_poller.py
@@ -7,7 +7,6 @@ No other operating systems are supported at the moment
 """
 
 from datetime import datetime, timedelta
-from threading import Lock
 import logging
 import time
 from bluepy.btle import Peripheral, BTLEException
@@ -24,11 +23,8 @@ INVALID_DATA = b'\xaa\xbb\xcc\xdd\xee\xff\x99\x88wf\x00\x00\x00\x00\x00\x00'
 """Configure how long data is cached before new values are
 retrieved from the sensor.
 """
-UPDATE_INTERVAL = 5*60
 
 LOGGER = logging.getLogger(__name__)
-
-LOCK = Lock()
 
 
 class MiFloraPoller(object):
@@ -42,13 +38,9 @@ class MiFloraPoller(object):
         """
         self._mac = mac
         self._adapter = adapter
-        self._cache = None
         self._cache_timeout = timedelta(seconds=cache_timeout)
         self._last_read = None
-        self._fw_last_read = datetime.now()
-        self.retries = retries
-        self.ble_timeout = 10
-        self.lock = Lock()
+        self._retries = retries
         self._firmware_version = None
         self._battery = None
         self._name = None
@@ -57,16 +49,53 @@ class MiFloraPoller(object):
         self._moisture = None
         self._conductivity = None
 
-    def _fetch_name(self, peripheral):
-        """
-        Fetch the name of the sensor.
-        """
-        byte_array = self._retry(peripheral.readCharacteristic, [0x03])
-        self._name = byte_array.decode('ascii')
+    def battery_level(self):
+        """Return the battery level."""
+        self._fill_cache()
+        return self._battery
 
-    def _fill_cache(self,read_cached=True):
+    def firmware_version(self):
+        """ Return the firmware version. """
+        self._fill_cache()
+        return self._firmware_version
+
+    def name(self):
+        """Return the name of the sensor."""
+        self._fill_cache()
+        return self._name
+
+    def parameter_value(self, parameter, read_cached=True):
+        """
+        Return a value of one of the monitored paramaters.
+
+        This method will try to retrieve the data from cache and only
+        request it by bluetooth if no cached value is stored or the cache is
+        expired.
+        This behaviour can be overwritten by the "read_cached" parameter.
+        """
+        self._fill_cache(read_cached)
+        if parameter == MI_BATTERY:
+            return self.battery_level()
+        elif parameter == MI_CONDUCTIVITY:
+            return self._conductivity
+        elif parameter == MI_MOISTURE:
+            return self._moisture
+        elif parameter == MI_TEMPERATURE:
+            return self._temperature
+        elif parameter == MI_LIGHT:
+            return self._brightness
+        raise Exception('unknown parameter %s', parameter)
+
+    def _fill_cache(self, read_cached=True):
+        """Fetch new data from the sensor.
+
+        This will only update the data if:
+        - there are no previous measurements or
+        - read_cached is False or
+        - the measurements are older than 5 minutes
+        """
         if self._last_read is None or \
-               (self._last_read + timedelta(seconds=UPDATE_INTERVAL)) <= datetime.now() or \
+                (self._last_read + self._cache_timeout) <= datetime.now() or \
                 not read_cached:
             # TODO: pick the right adapter when creating the Peripheral
             peripheral = self._retry(Peripheral, [self._mac])
@@ -78,31 +107,24 @@ class MiFloraPoller(object):
             peripheral.disconnect()
             self._last_read = datetime.now()
 
+    def _fetch_name(self, peripheral):
+        """Fetch the name of the sensor."""
+        byte_array = self._retry(peripheral.readCharacteristic, [0x03])
+        self._name = byte_array.decode('ascii')
+
     def _fetch_version_battery(self, peripheral):
+        """Fetch the version number and battery level from the sensor."""
         result = self._retry(peripheral.readCharacteristic, [0x38])
         self._decode_characteristic_38(result)
 
     def _fetch_measurements(self, peripheral):
+        """Fetch the measurements from the sensor."""
         if self._firmware_version >= "2.6.6":
             self._retry(peripheral.writeCharacteristic, [0x33, bytes([0xA0, 0x1F]), True])
         result = self._retry(peripheral.readCharacteristic, [0x35])
-        LOGGER.debug('Raw data for char 0x35: %s', self._format_bytes(result))
-
         if result == INVALID_DATA:
             raise Exception('Received invalid data from the sensor')
         self._decode_characteristic_35(result)
-
-    def battery_level(self):
-        self._fill_cache()
-        return self._battery
-
-    def firmware_version(self):
-        """ Return the firmware version. """
-        self._fill_cache()
-        return self._firmware_version
-
-    def name(self):
-        return self._name
 
     def _decode_characteristic_38(self, byte_array):
         """Perform byte magic when decoding the data from the sensor."""
@@ -125,44 +147,21 @@ class MiFloraPoller(object):
         self._moisture = int.from_bytes(result[7:8], byteorder=BYTEORDER)
         self._conductivity = int.from_bytes(result[8:10], byteorder=BYTEORDER)
 
+        LOGGER.debug('Raw data for char 0x35: %s', self._format_bytes(result))
         LOGGER.debug('temp: %f', self._temperature)
         LOGGER.debug('brightness: %d', self._brightness)
         LOGGER.debug('conductivity: %d', self._conductivity)
         LOGGER.debug('moisture: %d', self._moisture)
 
-    def parameter_value(self, parameter, read_cached=True):
-        """
-        Return a value of one of the monitored paramaters.
-
-        This method will try to retrieve the data from cache and only
-        request it by bluetooth if no cached value is stored or the cache is
-        expired.
-        This behaviour can be overwritten by the "read_cached" parameter.
-        """
-
-        self._fill_cache(read_cached)
-        if parameter == MI_BATTERY:
-            return self.battery_level()
-        elif parameter == MI_CONDUCTIVITY:
-            return self._conductivity
-        elif parameter == MI_MOISTURE:
-            return self._moisture
-        elif parameter == MI_TEMPERATURE:
-            return self._temperature
-        elif parameter == MI_LIGHT:
-            return self._brightness
-        raise Exception('unknown parameter %s', parameter)
-
-    @staticmethod
-    def _retry(func, args, num_tries=5, sleep_time=0.5):
+    def _retry(self, func, args, sleep_time=0.5):
         """Retry calling a function on Exception."""
-        for i in range(0, num_tries):
+        for i in range(0, self._retries):
             try:
                 return func(*args)
             except BTLEException as exception:
-                LOGGER.info("function %s failed (try %d of %d)", func, i+1, num_tries)
+                LOGGER.info("function %s failed (try %d of %d)", func, i+1, self._retries)
                 time.sleep(sleep_time * (2 ^ i))
-                if i == num_tries - 1:
+                if i == self._retries - 1:
                     LOGGER.error('retry finally failed!')
                     raise exception
                 else:

--- a/miflora/tests/mock_peripheral.py
+++ b/miflora/tests/mock_peripheral.py
@@ -1,0 +1,80 @@
+import binascii
+import logging
+from bluepy.btle import BTLEException
+from miflora.miflora_poller import BYTEORDER
+from miflora import miflora_poller as mi
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _str2bytearray(hex_string):
+    return binascii.unhexlify(hex_string.replace(' ', ''))
+
+VALUE_DEVICE_INFO = _str2bytearray("62 1d 32 2e 38 2e 36")
+VALUE_MEASUREMENT = _str2bytearray("ce 00 00 35 00 00 00 1c c8 00 02 3c 00 fb 34 9b")
+VALUE_NO_DATA = (0).to_bytes(16, BYTEORDER)
+VALUE_DEVICE_TIME = (36000).to_bytes(32, BYTEORDER)
+
+
+class MockPeripheral:
+    def __init__(self, history_items=10, **kwargs):
+        self.history_items = history_items
+        self.cache = {
+            0x03: b'Test Flower Care',
+            0x35: VALUE_NO_DATA,
+            0x38: VALUE_DEVICE_INFO,
+            0x41: VALUE_DEVICE_TIME,
+            0x3c: VALUE_NO_DATA
+        }
+        self._read_log = []
+        self._connected = False
+
+    @property
+    def _helper(self):
+        return 1 if self._connected else None
+
+    def readCharacteristic(self, handle):
+        if self._connected is False:
+            raise BTLEException(BTLEException.INTERNAL_ERROR, "Helper not started (did you call connect()?)")
+
+        response = self.cache.get(handle, b'\x00\x00')
+
+        self._read_log.append((handle, response))
+        LOGGER.debug("read(0x{:x}) value: %a".format(handle, [x for x in response]))
+        return response
+
+    def writeCharacteristic(self, handle, payload, withResponse=False):
+        LOGGER.debug("write(0x{:x}) payload: %a".format(handle, payload))
+        if self._connected is False:
+            raise BTLEException(BTLEException.INTERNAL_ERROR, "Helper not started (did you call connect()?)")
+
+        if handle == mi.handle_measurement_control and payload[0] == 0xa0:
+            self.cache[mi.handle_measurement_read] = VALUE_MEASUREMENT
+
+        if handle == mi.handle_history_control:
+            if payload == mi.cmd_history_read_init:
+                self.cache[mi.handle_history_read] = (self.history_items).to_bytes(2, BYTEORDER) + \
+                                                     (0).to_bytes(14, BYTEORDER)
+
+            elif payload[0] == int.from_bytes(b'\xa1', BYTEORDER):
+                address = int.from_bytes(payload[1:3], byteorder=BYTEORDER)
+                self.cache[mi.handle_history_read] = \
+                    (3600*(self.history_items - address)).to_bytes(4, BYTEORDER) + \
+                    int(20.6*10).to_bytes(2, BYTEORDER) + b'\x00' + \
+                    (1066).to_bytes(3, BYTEORDER) + b'\x00' + (57).to_bytes(1, BYTEORDER) + \
+                    (123).to_bytes(2, BYTEORDER) + b'\x00\x00'
+
+            elif payload == mi.cmd_history_read_success:
+                self.cache[mi.handle_history_read] = VALUE_NO_DATA
+                self.history_items = 0
+
+            elif payload == mi.cmd_history_read_failed:
+                self.cache[mi.handle_history_read] = VALUE_NO_DATA
+
+        return {'resp': 'wr'} if withResponse else None
+
+    def connect(self, *args, **kwargs):
+        self._connected = True
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._connected = False

--- a/miflora/tests/test_parse.py
+++ b/miflora/tests/test_parse.py
@@ -1,38 +1,73 @@
-'''
-Created on Jul 8, 2016
+##############################################
+#
+# This is open source software licensed under the Apache License 2.0
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+##############################################
 
-@author: matuschd
-'''
+import sys
 import unittest
-from miflora.miflora_poller import MiFloraPoller, \
-    MI_CONDUCTIVITY, MI_MOISTURE, MI_LIGHT, MI_TEMPERATURE
-from datetime import datetime
+if sys.version_info < (3, 0):
+    import mock
+else:
+    import unittest.mock as mock
+import logging
+import binascii
+from miflora.miflora_poller import MiFloraPoller
+from bluepy.btle import BTLEException
+
+# setup logging
+logger = logging.getLogger()
+logger.level = logging.DEBUG
+stream_handler = logging.StreamHandler(sys.stdout)
+logger.addHandler(stream_handler)
 
 
-class KNXConversionTest(unittest.TestCase):
+class TestMiSensor(unittest.TestCase):
 
-    def test_parsing(self):
-        """Does the Mi Flora data parser works correctly?"""
-        poller = MiFloraPoller(None)
-        data = [0x25, 0x01, 0x00, 0xf7, 0x26, 0x00, 0x00, 0x28,
-                0x0e, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
-        poller._cache = data
-        self._last_read = datetime.now()
-        self.assertEquals(poller._parse_data()[MI_CONDUCTIVITY], 270)
-        self.assertEquals(poller._parse_data()[MI_MOISTURE], 40)
-        self.assertEquals(poller._parse_data()[MI_LIGHT], 9975)
-        self.assertEquals(poller._parse_data()[MI_TEMPERATURE], 29.3)
+    def setUp(self):
+        self.failcount = 0
 
-        data = [0xf2, 0x00, 0x00, 0x79, 0x00, 0x00, 0x00, 0x10,
-                0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x000]
-        poller._cache = data
-        self._last_read = datetime.now()
-        self.assertEquals(poller._parse_data()[MI_CONDUCTIVITY], 101)
-        self.assertEquals(poller._parse_data()[MI_MOISTURE], 16)
-        self.assertEquals(poller._parse_data()[MI_LIGHT], 121)
-        self.assertEquals(poller._parse_data()[MI_TEMPERATURE], 24.2)
+    def _fail_for_n(self, n):
+        self.failcount += 1
+        if self.failcount < n:
+            raise BTLEException(0, 'test exception')
+        return self.failcount
 
+    def test_retry1(self):
+        s = MiFloraPoller('11:22:33')
+        s._retry(self._fail_for_n, [1])
 
-if __name__ == "__main__":
-    #import sys;sys.argv = ['', 'Test.testName']
-    unittest.main()
+    def test_retry6(self):
+        s = MiFloraPoller('11:22:33')
+        try:
+            s._retry(self._fail_for_n, [10])
+        except BTLEException:
+            pass
+        else:
+            self.fail('should have thrown an exception')
+
+    def test_format_bytes(self):
+        self.assertEquals('ff 00 1b', MiFloraPoller._format_bytes(bytes([0xff, 0x00, 0x1b])))
+
+    @mock.patch('miflora.miflora_poller.Peripheral')
+    def test_decode_38(self, mock_peripheral):
+        test_data = self._str2bytearray("62 1d 32 2e 38 2e 36")
+        s = MiFloraPoller('11:22:33')
+        s._decode_characteristic_38(test_data)
+        self.assertEqual(s._battery, 98)
+        self.assertEqual(s._firmware_version, '2.8.6')
+
+    @mock.patch('miflora.miflora_poller.Peripheral')
+    def test_decode_35(self, mock_peripheral):
+        test_data = self._str2bytearray("ce 00 00 35 00 00 00 1c c8 00 02 3c 00 fb 34 9b")
+        s = MiFloraPoller('11:22:33')
+        s._decode_characteristic_35(test_data)
+        self.assertEqual(s._temperature, 20.6)
+        self.assertEqual(s._moisture, 28)
+        self.assertEqual(s._conductivity, 200)
+        self.assertEqual(s._brightness, 53)
+
+    @staticmethod
+    def _str2bytearray(hex_string):
+        return binascii.unhexlify(hex_string.replace(' ',''))

--- a/miflora/tests/test_parse.py
+++ b/miflora/tests/test_parse.py
@@ -5,16 +5,22 @@
 #
 ##############################################
 
+import binascii
+import logging
 import sys
 import unittest
+
+from miflora.miflora_poller import MiFloraPoller, \
+    MI_TEMPERATURE, MI_LIGHT, MI_CONDUCTIVITY, MI_MOISTURE, \
+    MI_BATTERY, MI_FIRMWARE, BYTEORDER
+from miflora.decorators import retry
+from miflora.tests.mock_peripheral import MockPeripheral
+
 if sys.version_info < (3, 0):
     import mock
 else:
     import unittest.mock as mock
-import logging
-import binascii
-from miflora.miflora_poller import MiFloraPoller
-from bluepy.btle import BTLEException
+
 
 # setup logging
 logger = logging.getLogger()
@@ -28,46 +34,82 @@ class TestMiSensor(unittest.TestCase):
     def setUp(self):
         self.failcount = 0
 
+    @retry(3, Exception)
     def _fail_for_n(self, n):
         self.failcount += 1
         if self.failcount < n:
-            raise BTLEException(0, 'test exception')
+            raise Exception('Failed %d times' % self.failcount)
         return self.failcount
 
-    def test_retry1(self):
-        s = MiFloraPoller('11:22:33')
-        s._retry(self._fail_for_n, [1])
+    def test_retry3(self):
+        assert self._fail_for_n(3) == 3
 
-    def test_retry6(self):
+    def test_retry4(self):
+        self.assertRaises(Exception, self._fail_for_n(4))
+
+    @mock.patch('miflora.miflora_poller.Peripheral', new=MockPeripheral)
+    def test_autoconnect(self):
         s = MiFloraPoller('11:22:33')
-        try:
-            s._retry(self._fail_for_n, [10])
-        except BTLEException:
-            pass
-        else:
-            self.fail('should have thrown an exception')
+        assert s.battery_level == 98
+        assert s.connected is False
+        with s:
+            assert s.battery_level == 98
+            assert s.connected is True
+        assert s.connected is False
+
+    @mock.patch('miflora.miflora_poller.Peripheral', new=MockPeripheral)
+    def test_measure(self):
+        s = MiFloraPoller('11:22:33')
+        with s:
+            assert s.battery_level == 98
+            assert s.firmware_version == '2.8.6'
+            assert s.light == 53
+            assert s.temperature == 20.6
+            assert s.conductivity == 200
+            assert s.moisture == 28
+
+        # Check loads and connection status
+        assert [x[0] for x in s._peripheral._read_log] == [0x38, 0x35, 0x41]
+        assert s._peripheral._connected is False
+
+    @mock.patch('miflora.miflora_poller.Peripheral', new=MockPeripheral)
+    def test_history(self):
+        s = MiFloraPoller('11:22:33')
+
+        assert s._peripheral.history_items == 10
+        with s:
+            data = s._fetch_history()
+        assert s._peripheral.history_items == 0
+        assert len(s._peripheral._read_log) == 12
+        assert s._fetch_history() is None
 
     def test_format_bytes(self):
         self.assertEquals('ff 00 1b', MiFloraPoller._format_bytes(bytes([0xff, 0x00, 0x1b])))
 
-    @mock.patch('miflora.miflora_poller.Peripheral')
-    def test_decode_38(self, mock_peripheral):
-        test_data = self._str2bytearray("62 1d 32 2e 38 2e 36")
-        s = MiFloraPoller('11:22:33')
-        s._decode_characteristic_38(test_data)
-        self.assertEqual(s._battery, 98)
-        self.assertEqual(s._firmware_version, '2.8.6')
+    def test_int2bytes(self):
+        assert (767).to_bytes(2, BYTEORDER) == b'\xff\x02'
 
-    @mock.patch('miflora.miflora_poller.Peripheral')
-    def test_decode_35(self, mock_peripheral):
-        test_data = self._str2bytearray("ce 00 00 35 00 00 00 1c c8 00 02 3c 00 fb 34 9b")
+    @mock.patch('miflora.miflora_poller.Peripheral', new=MockPeripheral)
+    def test_decode_device_info(self):
+        test_data = _str2bytearray("62 1d 32 2e 38 2e 36")
         s = MiFloraPoller('11:22:33')
-        s._decode_characteristic_35(test_data)
-        self.assertEqual(s._temperature, 20.6)
-        self.assertEqual(s._moisture, 28)
-        self.assertEqual(s._conductivity, 200)
-        self.assertEqual(s._brightness, 53)
+        data = s._decode_device_info(test_data)
+        assert data[MI_BATTERY] == 98
+        assert data[MI_FIRMWARE] == '2.8.6'
 
-    @staticmethod
-    def _str2bytearray(hex_string):
-        return binascii.unhexlify(hex_string.replace(' ',''))
+
+    @mock.patch('miflora.miflora_poller.Peripheral', new=MockPeripheral)
+    def test_decode_measurement(self):
+        test_data = _str2bytearray("ce 00 00 35 00 00 00 1c c8 00 02 3c 00 fb 34 9b")
+        s = MiFloraPoller('11:22:33')
+        data = s._decode_measurement(test_data)
+        assert data[MI_TEMPERATURE] == 20.6
+        assert data[MI_MOISTURE] == 28
+        assert data[MI_CONDUCTIVITY] == 200
+        assert data[MI_LIGHT] == 53
+
+
+def _str2bytearray(hex_string):
+    return binascii.unhexlify(hex_string.replace(' ', ''))
+
+

--- a/setup.py
+++ b/setup.py
@@ -18,4 +18,5 @@ setup(name='miflora',
       ],
       packages=find_packages(),
       keywords='plant sensor bluetooth low-energy ble',
+      install_requires = ['bluepy'],
       zip_safe=False)


### PR DESCRIPTION
A proposal for reading historical measurement data off the device

Builds upon pull request #23 as speed and connection control was needed

Notes:
- Only tested against firmware version 2.9.2
- Changes cache and retry implementations for decorators
- Introduces a simple mock bluepy Peripheral to imitate the device during tests
