### PR TITLE
Handle uncaught gatttool stderr messages

### DIFF
--- a/miflora/miflora_poller.py
+++ b/miflora/miflora_poller.py
@@ -57,6 +57,7 @@ def write_ble(mac, handle, value, retries=3, timeout=20, adapter='hci0'):
             with Popen(cmd,
                        shell=True,
                        stdout=PIPE,
+                       stderr=PIPE,
                        preexec_fn=os.setsid) as process:
                 try:
                     result = process.communicate(timeout=timeout)[0]
@@ -114,6 +115,7 @@ def read_ble(mac, handle, retries=3, timeout=20, adapter='hci0'):
             with Popen(cmd,
                        shell=True,
                        stdout=PIPE,
+                       stderr=PIPE,
                        preexec_fn=os.setsid) as process:
                 try:
                     result = process.communicate(timeout=timeout)[0]


### PR DESCRIPTION
This change fixes so far not caught output to stderr, which should not be there inside a library.

Examples:
```
connect error: Connection timed out (110)
connect error: Transport endpoint is not connected (107)
```

This is a rather small change and should not break any other open PR.