### PR TITLE
Check prerequisites and cache check functions

### DIFF
--- a/miflora/miflora_poller.py
+++ b/miflora/miflora_poller.py
@@ -187,11 +187,11 @@ class MiFloraPoller(object):
         if not name:
             raise IOError("Could not read data from Mi Flora sensor %s", self._mac)
         return ''.join(chr(n) for n in name)
-
+    
     def clear_cache(self):
         self._cache = None
         self._last_read = None
-        
+    
     def fill_cache(self):
         firmware_version = self.firmware_version()
         if not firmware_version:
@@ -220,7 +220,7 @@ class MiFloraPoller(object):
                 timedelta(seconds=300)
     
     def cache_available(self):
-        return self._cache not None
+        return self._cache is not None
     
     def battery_level(self):
         """


### PR DESCRIPTION
We need to check if gatttool is available prior to using the current implementation of `write_ble/read_ble`.
It is also important to know that data is available through the cache and in certain situations you might want to purge the cache.