### PR TITLE
Implemented scanning for devices in bluepy backend

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -8,18 +8,47 @@ from miflora.miflora_poller import MiFloraPoller, \
     MI_CONDUCTIVITY, MI_MOISTURE, MI_LIGHT, MI_TEMPERATURE, MI_BATTERY
 from miflora.backends.gatttool import GatttoolBackend
 from miflora.backends.bluepy import BluepyBackend
+from miflora import miflora_scanner
 
 
 def valid_miflora_mac(mac, pat=re.compile(r"C4:7C:8D:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}")):
-    if not pat.match(mac):
+    if not pat.match(mac.upper()):
         raise argparse.ArgumentTypeError('The MAC address "{}" seems to be in the wrong format'.format(mac))
     return mac
 
 
+def poll(args, backend):
+    poller = MiFloraPoller(args.mac, backend)
+    print("Getting data from Mi Flora")
+    print("FW: {}".format(poller.firmware_version()))
+    print("Name: {}".format(poller.name()))
+    print("Temperature: {}".format(poller.parameter_value(MI_TEMPERATURE)))
+    print("Moisture: {}".format(poller.parameter_value(MI_MOISTURE)))
+    print("Light: {}".format(poller.parameter_value(MI_LIGHT)))
+    print("Conductivity: {}".format(poller.parameter_value(MI_CONDUCTIVITY)))
+    print("Battery: {}".format(poller.parameter_value(MI_BATTERY)))
+
+
+def scan(args, backend):
+    print('Scanning for 10 seconds...')
+    devices = miflora_scanner.scan(backend, 10)
+    print('Found {} devices:'.format(len(devices)))
+    for d in devices:
+        print('  {}'.format(d))
+
+
 parser = argparse.ArgumentParser()
-parser.add_argument('mac', type=valid_miflora_mac)
 parser.add_argument('--backend', choices=['gatttool', 'bluepy'], default='gatttool')
 parser.add_argument('-v', '--verbose', action='store_const', const=True)
+subparsers = parser.add_subparsers(help='sub-command help')
+
+parser_poll = subparsers.add_parser('poll', help='poll data from a sensor')
+parser_poll.add_argument('mac', type=valid_miflora_mac)
+parser_poll.set_defaults(func=poll)
+
+parser_scan = subparsers.add_parser('scan', help='scan for devices')
+parser_scan.set_defaults(func=scan)
+
 args = parser.parse_args()
 
 backend = None
@@ -33,13 +62,4 @@ else:
 if args.verbose:
     logging.basicConfig(level=logging.DEBUG)
 
-poller = MiFloraPoller(args.mac, backend)
-
-print("Getting data from Mi Flora")
-print("FW: {}".format(poller.firmware_version()))
-print("Name: {}".format(poller.name()))
-print("Temperature: {}".format(poller.parameter_value(MI_TEMPERATURE)))
-print("Moisture: {}".format(poller.parameter_value(MI_MOISTURE)))
-print("Light: {}".format(poller.parameter_value(MI_LIGHT)))
-print("Conductivity: {}".format(poller.parameter_value(MI_CONDUCTIVITY)))
-print("Battery: {}".format(poller.parameter_value(MI_BATTERY)))
+args.func(args, backend)

--- a/miflora/backends/__init__.py
+++ b/miflora/backends/__init__.py
@@ -88,7 +88,8 @@ class AbstractBackend(object):
         """
         raise NotImplementedError
 
-    def scan_for_devices(self, timeout):
+    @staticmethod
+    def scan_for_devices(timeout):
         """Scan for additional devices.
 
         Returns a list of all the mac addresses of Xiaomi Mi Flower sensor that could be found.

--- a/miflora/backends/bluepy.py
+++ b/miflora/backends/bluepy.py
@@ -1,33 +1,61 @@
+"""Backend for Miflora using the bluepy library."""
 from miflora.backends import AbstractBackend, BluetoothBackendException
 
 
 class BluepyBackend(AbstractBackend):
+    """Backend for Miflora using the bluepy library."""
 
     def __init__(self, adapter='hci0'):
+        """Create new instance of the backend."""
         super(self.__class__, self).__init__(adapter)
         self._peripheral = None
 
     def connect(self, mac):
+        """Connect to a device."""
         from bluepy.btle import Peripheral
 
         self._peripheral = Peripheral(mac)
 
     def disconnect(self):
+        """Disconnect from a device."""
         self._peripheral.disconnect()
         self._peripheral = None
 
     def read_handle(self, handle):
+        """Read a handle from the device.
+
+        You must be connected to do this.
+        """
         if self._peripheral is None:
             raise BluetoothBackendException('not connected to backend')
         return self._peripheral.readCharacteristic(handle)
 
     def write_handle(self, handle, value):
+        """Write a handle from the device.
+
+        You must be connected to do this.
+        """
         if self._peripheral is None:
             raise BluetoothBackendException('not connected to backend')
         return self._peripheral.writeCharacteristic(handle, value, True)
 
     def check_backend(self):
+        """Check if the backend is available."""
         try:
             import bluepy.btle  # noqa: F401
         except ImportError:
             raise BluetoothBackendException('bluepy not found')
+
+    @staticmethod
+    def scan_for_devices(timeout):
+        """Scan for bluetooth low energy devices.
+
+        Note this must be run as root!"""
+        from bluepy.btle import Scanner
+
+        scanner = Scanner()
+        result = []
+        for device in scanner.scan(timeout):
+            print(device.addr, device.getValueText(9))
+            result.append((device.addr, device.getValueText(9)))
+        return result

--- a/miflora/backends/bluepy.py
+++ b/miflora/backends/bluepy.py
@@ -56,6 +56,5 @@ class BluepyBackend(AbstractBackend):
         scanner = Scanner()
         result = []
         for device in scanner.scan(timeout):
-            print(device.addr, device.getValueText(9))
             result.append((device.addr, device.getValueText(9)))
         return result

--- a/miflora/miflora_scanner.py
+++ b/miflora/miflora_scanner.py
@@ -1,0 +1,20 @@
+"""Scan for miflora devices"""
+
+# use only lower case names here
+VALID_DEVICE_NAMES = ['flower mate',
+                      'flower care']
+
+DEVICE_PREFIX = 'C4:7C:8D:'
+
+
+def scan(backend, timeout=10):
+    """Scan for miflora devices.
+
+    Note: this must be run as root!
+    """
+    result = []
+    for (mac, name) in backend.scan_for_devices(timeout):
+        if (name is not None and name.lower() in VALID_DEVICE_NAMES) or \
+                mac is not None and mac.upper().startswith(DEVICE_PREFIX):
+            result.append(mac.upper())
+    return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-bluepy==1.1.2
+bluepy==1.1.4
 pytest
 pytest-cov

--- a/test/integration_tests/test_bluepy_backend.py
+++ b/test/integration_tests/test_bluepy_backend.py
@@ -11,3 +11,14 @@ class TestBluepyBackend(TestGatttoolBackend):
 
     def setUp(self):
         self.backend = BluepyBackend()
+
+    def test_scan(self):
+        """Test scanning for devices.
+
+        Note: fore the test to pass, there must be at least one BTLE device
+        near by.
+        """
+        devices = BluepyBackend.scan_for_devices(5)
+        self.assertGreater(len(devices), 0)
+        for d in devices:
+            self.assertIsNotNone(d)

--- a/test/integration_tests/test_demo.py
+++ b/test/integration_tests/test_demo.py
@@ -10,13 +10,17 @@ class TestDemoPy(unittest.TestCase):
     root_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
     @pytest.mark.usefixtures("mac")
-    def test_bluepy(self):
+    def test_bluepy_poll(self):
         self.assertIsNotNone(self.mac)
-        cmd = './demo.py --backend bluepy {}'.format(self.mac)
+        cmd = './demo.py --backend bluepy poll {}'.format(self.mac)
         subprocess.check_call(cmd, shell=True, cwd=self.root_dir)
 
     @pytest.mark.usefixtures("mac")
-    def test_gatttool(self):
+    def test_gatttool_poll(self):
         self.assertIsNotNone(self.mac)
-        cmd = './demo.py --backend gatttool {}'.format(self.mac)
+        cmd = './demo.py --backend gatttool poll {}'.format(self.mac)
+        subprocess.check_call(cmd, shell=True, cwd=self.root_dir)
+
+    def test_bluepy_scan(self):
+        cmd = './demo.py --backend bluepy scan'
         subprocess.check_call(cmd, shell=True, cwd=self.root_dir)

--- a/test/unit_tests/test_miflora_scanner.py
+++ b/test/unit_tests/test_miflora_scanner.py
@@ -1,0 +1,28 @@
+"""Test the miflora_scanner."""
+
+from miflora import miflora_scanner
+import unittest
+
+
+class TestMifloraScanner(unittest.TestCase):
+    """Test the miflora_scanner."""
+
+    def test_scan(self):
+        """Test the scan function."""
+
+        class _MockBackend(object):
+            """Mock of the backend, always returning the same devices."""
+
+            @staticmethod
+            def scan_for_devices(_):
+                return [('00:FF:FF:FF:FF:FF', None),
+                        ('01:FF:FF:FF:FF:FF', 'Flower mate'),
+                        ('02:FF:FF:FF:FF:FF', 'Flower care'),
+                        ('c4:7c:8d:FF:FF:FF', 'random name'),
+                        ]
+
+        devices = miflora_scanner.scan(_MockBackend, 0)
+        self.assertEqual(len(devices), 3)
+        self.assertEqual(devices[0], '01:FF:FF:FF:FF:FF')
+        self.assertEqual(devices[1], '02:FF:FF:FF:FF:FF')
+        self.assertEqual(devices[2], 'C4:7C:8D:FF:FF:FF')


### PR DESCRIPTION
If you're using the bluepy backend you can now scan for miflora devices.

I also changed the interface of demo.py. It now supports subcommands:
```
./demo.py --backend bluepy scan
./demo.py poll 11:22:33:44:55:66
```
