### PR TITLE
Improve check_backend()

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -6,9 +6,9 @@ import logging
 
 from miflora.miflora_poller import MiFloraPoller, \
     MI_CONDUCTIVITY, MI_MOISTURE, MI_LIGHT, MI_TEMPERATURE, MI_BATTERY
-from miflora.backends.gatttool import GatttoolBackend
 from miflora.backends.bluepy import BluepyBackend
-from miflora import miflora_scanner
+from miflora.backends.gatttool import GatttoolBackend
+from miflora import miflora_scanner, available_backends
 
 
 def valid_miflora_mac(mac, pat=re.compile(r"C4:7C:8D:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}")):
@@ -17,7 +17,8 @@ def valid_miflora_mac(mac, pat=re.compile(r"C4:7C:8D:[0-9A-F]{2}:[0-9A-F]{2}:[0-
     return mac
 
 
-def poll(args, backend):
+def poll(args):
+    backend = _get_backend(args)
     poller = MiFloraPoller(args.mac, backend)
     print("Getting data from Mi Flora")
     print("FW: {}".format(poller.firmware_version()))
@@ -29,12 +30,28 @@ def poll(args, backend):
     print("Battery: {}".format(poller.parameter_value(MI_BATTERY)))
 
 
-def scan(args, backend):
+def scan(args):
+    backend = _get_backend(args)
     print('Scanning for 10 seconds...')
     devices = miflora_scanner.scan(backend, 10)
     print('Found {} devices:'.format(len(devices)))
     for d in devices:
         print('  {}'.format(d))
+
+
+def _get_backend(args):
+    if args.backend == 'gatttool':
+        backend = GatttoolBackend
+    elif args.backend == 'bluepy':
+        backend = BluepyBackend
+    else:
+        raise Exception('unknown backend: {}'.format(args.backend))
+    return backend
+
+
+def list_backends(args):
+    backends = [b.__name__ for b in available_backends()]
+    print('\n'.join(backends))
 
 
 parser = argparse.ArgumentParser()
@@ -49,17 +66,12 @@ parser_poll.set_defaults(func=poll)
 parser_scan = subparsers.add_parser('scan', help='scan for devices')
 parser_scan.set_defaults(func=scan)
 
-args = parser.parse_args()
+parser_scan = subparsers.add_parser('backends', help='list the available backends')
+parser_scan.set_defaults(func=list_backends)
 
-backend = None
-if args.backend == 'gatttool':
-    backend = GatttoolBackend
-elif args.backend == 'bluepy':
-    backend = BluepyBackend
-else:
-    raise Exception('unknown backend: {}'.format(args.backend))
+args = parser.parse_args()
 
 if args.verbose:
     logging.basicConfig(level=logging.DEBUG)
 
-args.func(args, backend)
+args.func(args)

--- a/demo.py
+++ b/demo.py
@@ -6,9 +6,7 @@ import logging
 
 from miflora.miflora_poller import MiFloraPoller, \
     MI_CONDUCTIVITY, MI_MOISTURE, MI_LIGHT, MI_TEMPERATURE, MI_BATTERY
-from miflora.backends.bluepy import BluepyBackend
-from miflora.backends.gatttool import GatttoolBackend
-from miflora import miflora_scanner, available_backends
+from miflora import miflora_scanner, available_backends, BluepyBackend, GatttoolBackend
 
 
 def valid_miflora_mac(mac, pat=re.compile(r"C4:7C:8D:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}")):

--- a/miflora/__init__.py
+++ b/miflora/__init__.py
@@ -1,7 +1,7 @@
 import sys
-from miflora.backends.bluepy import BluepyBackend
-from miflora.backends.gatttool import GatttoolBackend
 
+# This check must be run first, so that it fails before loading the other modules.
+# Otherwise we do not get a clean error message.
 if sys.version_info <= (3, 4):
     raise ValueError('this library requires at least Python 3.4. ' +
                      'You\'re running version {}.{} from {}.'.format(
@@ -10,6 +10,8 @@ if sys.version_info <= (3, 4):
                         sys.executable))
 
 
+from miflora.backends.bluepy import BluepyBackend
+from miflora.backends.gatttool import GatttoolBackend
 _ALL_BACKENDS = [BluepyBackend, GatttoolBackend]
 
 

--- a/miflora/__init__.py
+++ b/miflora/__init__.py
@@ -10,8 +10,8 @@ if sys.version_info <= (3, 4):
                         sys.executable))
 
 
-from miflora.backends.bluepy import BluepyBackend
-from miflora.backends.gatttool import GatttoolBackend
+from miflora.backends.bluepy import BluepyBackend  # noqa: E402
+from miflora.backends.gatttool import GatttoolBackend  # noqa: E402
 _ALL_BACKENDS = [BluepyBackend, GatttoolBackend]
 
 

--- a/miflora/__init__.py
+++ b/miflora/__init__.py
@@ -1,4 +1,6 @@
 import sys
+from miflora.backends.bluepy import BluepyBackend
+from miflora.backends.gatttool import GatttoolBackend
 
 if sys.version_info <= (3, 4):
     raise ValueError('this library requires at least Python 3.4. ' +
@@ -6,3 +8,11 @@ if sys.version_info <= (3, 4):
                         sys.version_info.major,
                         sys.version_info.minor,
                         sys.executable))
+
+
+_ALL_BACKENDS = [BluepyBackend, GatttoolBackend]
+
+
+def available_backends():
+    """Returns a list of all available backends."""
+    return [b for b in _ALL_BACKENDS if b.check_backend()]

--- a/miflora/backends/__init__.py
+++ b/miflora/backends/__init__.py
@@ -80,7 +80,8 @@ class AbstractBackend(object):
     def read_handle(self, handle):
         raise NotImplementedError
 
-    def check_backend(self):
+    @staticmethod
+    def check_backend():
         """Check if the backend is available on the current system.
 
         Does nothing if the backend is available, throws a BluetoothBackendException

--- a/miflora/backends/__init__.py
+++ b/miflora/backends/__init__.py
@@ -84,8 +84,7 @@ class AbstractBackend(object):
     def check_backend():
         """Check if the backend is available on the current system.
 
-        Does nothing if the backend is available, throws a BluetoothBackendException
-        if it's not available.
+        Returns True if the backend is available and False otherwise
         """
         raise NotImplementedError
 

--- a/miflora/backends/bluepy.py
+++ b/miflora/backends/bluepy.py
@@ -53,9 +53,9 @@ class BluepyBackend(AbstractBackend):
         try:
             import bluepy.btle  # noqa: F401
             return True
-        except ImportError:
-            _LOGGER.error('bluepy not found')
-            return False
+        except ImportError as e:
+            _LOGGER.error('bluepy not found: %s', str(e))
+        return False
 
     @staticmethod
     def scan_for_devices(timeout):

--- a/miflora/backends/bluepy.py
+++ b/miflora/backends/bluepy.py
@@ -1,6 +1,9 @@
 """Backend for Miflora using the bluepy library."""
 import re
+import logging
 from miflora.backends import AbstractBackend, BluetoothBackendException
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class BluepyBackend(AbstractBackend):
@@ -44,12 +47,15 @@ class BluepyBackend(AbstractBackend):
             raise BluetoothBackendException('not connected to backend')
         return self._peripheral.writeCharacteristic(handle, value, True)
 
-    def check_backend(self):
+    @staticmethod
+    def check_backend():
         """Check if the backend is available."""
         try:
             import bluepy.btle  # noqa: F401
+            return True
         except ImportError:
-            raise BluetoothBackendException('bluepy not found')
+            _LOGGER.error('bluepy not found')
+            return False
 
     @staticmethod
     def scan_for_devices(timeout):

--- a/miflora/backends/gatttool.py
+++ b/miflora/backends/gatttool.py
@@ -155,7 +155,7 @@ class GatttoolBackend(AbstractBackend):
         except OSError as e:
             msg = 'gatttool not found: {}'.format(str(e))
             _LOGGER.error(msg)
-            return False
+        return False
 
     @staticmethod
     def byte_to_handle(b):

--- a/miflora/backends/gatttool.py
+++ b/miflora/backends/gatttool.py
@@ -147,14 +147,15 @@ class GatttoolBackend(AbstractBackend):
         _LOGGER.debug("Exit read_ble, no data (%s)", current_thread())
         return None
 
-    def check_backend(self):
+    @staticmethod
+    def check_backend():
         try:
             call('gatttool', stdout=PIPE, stderr=PIPE)
             return True
         except OSError as e:
             msg = 'gatttool not found: {}'.format(str(e))
             _LOGGER.error(msg)
-            raise BluetoothBackendException(msg)
+            return False
 
     @staticmethod
     def byte_to_handle(b):

--- a/miflora/backends/gatttool.py
+++ b/miflora/backends/gatttool.py
@@ -9,7 +9,7 @@ import os
 import logging
 import re
 from subprocess import Popen, PIPE, TimeoutExpired, signal, call
-from miflora.backends import AbstractBackend, BluetoothBackendException
+from miflora.backends import AbstractBackend
 import time
 
 _LOGGER = logging.getLogger(__name__)

--- a/test/integration_tests/test_demo.py
+++ b/test/integration_tests/test_demo.py
@@ -24,3 +24,11 @@ class TestDemoPy(unittest.TestCase):
     def test_bluepy_scan(self):
         cmd = './demo.py --backend bluepy scan'
         subprocess.check_call(cmd, shell=True, cwd=self.root_dir)
+
+    def test_list_backends(self):
+        """Test the list backends subcommand."""
+        cmd = './demo.py backends'
+        stdout = subprocess.check_output(cmd, shell=True, cwd=self.root_dir)
+        stdout = stdout.decode('utf-8')
+        self.assertIn('BluepyBackend', stdout)
+        self.assertIn('GatttoolBackend', stdout)

--- a/test/integration_tests/test_gatttool_backend.py
+++ b/test/integration_tests/test_gatttool_backend.py
@@ -35,4 +35,4 @@ class TestGatttoolBackend(unittest.TestCase):
             pass
 
     def test_check_backend(self):
-        self.backend.check_backend()
+        self.assertTrue(self.backend.check_backend())

--- a/test/unit_tests/test_available_backends.py
+++ b/test/unit_tests/test_available_backends.py
@@ -1,0 +1,29 @@
+"""Tests for miflora.available_backends."""
+import unittest
+from unittest import mock
+from miflora import available_backends, BluepyBackend, GatttoolBackend
+
+
+class TestAvailableBackends(unittest.TestCase):
+    """Tests for miflora.available_backends."""
+
+    @mock.patch('miflora.backends.gatttool.call', return_value=None)
+    def test_all(self, _):
+        """Tests with all backends available.
+
+        bluepy is installed via tox, gatttool is mocked.
+        """
+        backends = available_backends()
+        self.assertEqual(2, len(backends))
+        self.assertIn(BluepyBackend, backends)
+        self.assertIn(GatttoolBackend, backends)
+
+    @mock.patch('miflora.backends.gatttool.call', **{'side_effect': IOError()})
+    def test_one_missing(self, _):
+        """Tests with all backends available.
+
+        bluepy is installed via tox, gatttool is mocked.
+        """
+        backends = available_backends()
+        self.assertEqual(1, len(backends))
+        self.assertIn(BluepyBackend, backends)

--- a/test/unit_tests/test_bluepy.py
+++ b/test/unit_tests/test_bluepy.py
@@ -11,18 +11,27 @@ class TestBluepy(unittest.TestCase):
 
     @mock.patch('bluepy.btle.Peripheral')
     def test_adapter_configuration_default(self, mock_peripheral):
+        """Test adapter name pattern parsing."""
         be = BluepyBackend()
         be.connect(TEST_MAC)
         mock_peripheral.assert_called_with(TEST_MAC, iface=0)
 
     @mock.patch('bluepy.btle.Peripheral')
     def test_adapter_configuration_hci12(self, mock_peripheral):
+        """Test adapter name pattern parsing."""
         be = BluepyBackend(adapter='hci12')
         be.connect(TEST_MAC)
         mock_peripheral.assert_called_with(TEST_MAC, iface=12)
 
     @mock.patch('bluepy.btle.Peripheral')
     def test_adapter_configuration_invalid_adapter(self, _):
+        """Test adapter name pattern parsing."""
         be = BluepyBackend(adapter='somestring')
         with self.assertRaises(ValueError):
             be.connect(TEST_MAC)
+
+    def test_check_backend_ok(self):
+        """Test check_backend successfully."""
+        self.assertTrue(BluepyBackend.check_backend())
+
+    # TODO: find a way to test check_backend with an import error

--- a/test/unit_tests/test_gatttool.py
+++ b/test/unit_tests/test_gatttool.py
@@ -94,15 +94,12 @@ class TestGatttool(unittest.TestCase):
     @mock.patch('miflora.backends.gatttool.call', return_value=None)
     def test_check_backend_ok(self, call_mock):
         """Test check_backend successfully."""
-        be = GatttoolBackend()
-        be.check_backend()
+        self.assertTrue(GatttoolBackend().check_backend())
 
     @mock.patch('miflora.backends.gatttool.call', **{'side_effect': IOError()})
     def test_check_backend_fail(self, call_mock):
         """Test check_backend with IOError being risen."""
-        be = GatttoolBackend()
-        with self.assertRaises(BluetoothBackendException):
-            be.check_backend()
+        self.assertFalse(GatttoolBackend().check_backend())
 
 
 def _configure_popenmock(popen_mock, output_string):

--- a/test/unit_tests/test_gatttool.py
+++ b/test/unit_tests/test_gatttool.py
@@ -3,7 +3,6 @@
 import unittest
 from unittest import mock
 from miflora.backends.gatttool import GatttoolBackend
-from miflora.backends import BluetoothBackendException
 from test import TEST_MAC
 
 


### PR DESCRIPTION
I'm not happy with the interface of the check_backend() function:
- it should be static so you don't have to instantiate the class when checking.
- it should return True/False instead of throwing exceptions
- there should be a function available that returns the list of all available backends, so that you don't have to iterate and check manually.