### PR TITLE
improved error handling if sensor does not return any data

### DIFF
--- a/miflora/miflora_poller.py
+++ b/miflora/miflora_poller.py
@@ -189,4 +189,6 @@ class MiFloraPoller(object):
     @staticmethod
     def _format_bytes(raw_data):
         """Prettyprint a byte array."""
+        if raw_data is None:
+            return 'None'
         return ' '.join([format(c, "02x") for c in raw_data]).upper()

--- a/test/helper.py
+++ b/test/helper.py
@@ -26,7 +26,8 @@ class MockBackend(AbstractBackend):
         self.expected_write_handles = set()
         self.override_read_handles = dict()
         self.is_available = True
-        self.handle_0x35_raw = None
+        self._handle_0x35_raw_set = False
+        self._handle_0x35_raw = None
 
     def check_backend(self):
         """This backend is available when the field is set accordingly."""
@@ -67,8 +68,8 @@ class MockBackend(AbstractBackend):
 
     def _read_sensor_data(self):
         """Recreate sensor data from the fields of this class."""
-        if self.handle_0x35_raw is not None:
-            return self.handle_0x35_raw
+        if self._handle_0x35_raw_set:
+            return self._handle_0x35_raw
         result = [0xFE]*16
         temp = int(self.temperature * 10)
         result[0] = int(temp % 256)
@@ -86,3 +87,12 @@ class MockBackend(AbstractBackend):
     def _read_name(self):
         """Convert the name into a byte array and return it."""
         return [ord(c) for c in self.name]
+
+    @property
+    def handle_0x35_raw(self):
+        return self._handle_0x35_raw
+
+    @handle_0x35_raw.setter
+    def handle_0x35_raw(self, value):
+        self._handle_0x35_raw_set = True
+        self._handle_0x35_raw = value

--- a/test/unit_tests/test_miflora_poller.py
+++ b/test/unit_tests/test_miflora_poller.py
@@ -110,7 +110,6 @@ class TestMifloraPoller(unittest.TestCase):
         poller = MiFloraPoller(self.TEST_MAC, MockBackend)
         backend = self._get_backend(poller)
         backend.handle_0x35_raw = bytes(b'\x53\xFF\x00\x00\x00\x00\x00\x00\x00\x00\x02\x3C\x00\xFB\x34\x9B')
-        print(backend.handle_0x35_raw)
         self.assertAlmostEqual(-17.3, poller.parameter_value(MI_TEMPERATURE), delta=0.01)
 
     def test_clear_cache(self):
@@ -134,6 +133,13 @@ class TestMifloraPoller(unittest.TestCase):
         backend.temperature = 3.0
         self.assertAlmostEqual(3.0, poller.parameter_value(MI_TEMPERATURE), delta=0.01)
         self.assertTrue(poller.cache_available())
+
+    def test_no_answer(self):
+        poller = MiFloraPoller(self.TEST_MAC, MockBackend)
+        backend = self._get_backend(poller)
+        backend.handle_0x35_raw = None
+        with self.assertRaises(IOError):
+            poller.parameter_value(MI_TEMPERATURE)
 
     @staticmethod
     def _get_backend(poller):


### PR DESCRIPTION
Patch to address https://github.com/open-homeautomation/miflora/issues/79

The problem was just in the computation of the log output. So if we do not get any data, 'None' is printed in the log statement.