### PR TITLE
Support XIAOMI MIJIA Temp and Humidity Sensor v2

### DIFF
--- a/miflora/backends/__init__.py
+++ b/miflora/backends/__init__.py
@@ -70,6 +70,8 @@ class AbstractBackend(object):
     This class will be overridden by the different backends used by miflora.
     """
 
+    _DATA_MODE_LISTEN = bytes([0x01, 0x00])
+
     def __init__(self, adapter):
         self.adapter = adapter
 
@@ -89,6 +91,12 @@ class AbstractBackend(object):
         """Write a value to a handle.
 
         You must be connected to a device first."""
+        raise NotImplementedError
+
+    def wait_for_notification(self, handle, delegate, timeout):
+        """ registers as a listener and calls the delegate's handleNotification
+            for each notification received
+        """
         raise NotImplementedError
 
     def read_handle(self, handle):

--- a/miflora/backends/bluepy.py
+++ b/miflora/backends/bluepy.py
@@ -80,6 +80,14 @@ class BluepyBackend(AbstractBackend):
             raise BluetoothBackendException('not connected to backend')
         return self._peripheral.writeCharacteristic(handle, value, True)
 
+    @wrap_exception
+    def wait_for_notification(self, handle, delegate, timeout):
+        if self._peripheral is None:
+            raise BluetoothBackendException('not connected to backend')
+        self.write_handle(handle, self._DATA_MODE_LISTEN)
+        self._peripheral.withDelegate(delegate)
+        return self._peripheral.waitForNotifications(timeout)
+
     @staticmethod
     def check_backend():
         """Check if the backend is available."""

--- a/miflora/backends/gatttool.py
+++ b/miflora/backends/gatttool.py
@@ -122,8 +122,8 @@ class GatttoolBackend(AbstractBackend):
         @param: delegate - unused
         @param: timeout - ignored. the self.timeout is used
         """
-        return self.write_handle(handle, _DATA_MODE_LISTEN, true)
-        
+        return self.write_handle(handle, self._DATA_MODE_LISTEN, True)
+
 
     @wrap_exception
     def read_handle(self, handle):

--- a/miflora/backends/gatttool.py
+++ b/miflora/backends/gatttool.py
@@ -124,7 +124,6 @@ class GatttoolBackend(AbstractBackend):
         """
         return self.write_handle(handle, self._DATA_MODE_LISTEN, True)
 
-
     @wrap_exception
     def read_handle(self, handle):
         """Read from a BLE address.

--- a/miflora/backends/gatttool.py
+++ b/miflora/backends/gatttool.py
@@ -55,7 +55,7 @@ class GatttoolBackend(AbstractBackend):
         return self._mac is not None
 
     @wrap_exception
-    def write_handle(self, handle, value):
+    def write_handle(self, handle, value, listen=False):
         """Read from a BLE address.
 
         @param: mac - MAC address in format XX:XX:XX:XX:XX:XX
@@ -74,6 +74,9 @@ class GatttoolBackend(AbstractBackend):
         while attempt <= self.retries:
             cmd = "gatttool --device={} --char-write-req -a {} -n {} --adapter={}".format(
                 self._mac, self.byte_to_handle(handle), self.bytes_to_string(value), self.adapter)
+            if listen:
+                cmd = "gatttool --device={} --char-write-req -a {} -n {} --adapter={} --listen".format(
+                    self._mac, self.byte_to_handle(handle), self.bytes_to_string(value), self.adapter)
             _LOGGER.debug("Running gatttool with a timeout of %d: %s",
                           self.timeout, cmd)
 
@@ -108,6 +111,19 @@ class GatttoolBackend(AbstractBackend):
                 delay *= 2
 
         raise BluetoothBackendException("Exit write_ble, no data ({})".format(current_thread()))
+
+    @wrap_exception
+    def wait_for_notification(self, handle, delegate, timeout):
+        """Listen for characteristics changes from a BLE address.
+
+        @param: mac - MAC address in format XX:XX:XX:XX:XX:XX
+        @param: handle - BLE characteristics handle in format 0xXX
+                         a value of 0x0100 is written to register for listening
+        @param: delegate - unused
+        @param: timeout - ignored. the self.timeout is used
+        """
+        return self.write_handle(handle, _DATA_MODE_LISTEN, true)
+        
 
     @wrap_exception
     def read_handle(self, handle):

--- a/miflora/mitemp_poller.py
+++ b/miflora/mitemp_poller.py
@@ -1,0 +1,200 @@
+""""
+Read data from Mi Temp environmental (Temp and humidity) sensor.
+"""
+
+from datetime import datetime, timedelta
+import logging
+from threading import Lock
+from miflora.backends import BluetoothInterface, BluetoothBackendException
+
+_HANDLE_READ_BATTERY_LEVEL = 0x0018
+_HANDLE_READ_FIRMWARE_VERSION = 0x0024
+_HANDLE_READ_NAME = 0x03
+_HANDLE_READ_WRITE_SENSOR_DATA = 0x0010
+
+
+MI_TEMPERATURE = "temperature"
+MI_HUMIDITY = "humidity"
+MI_BATTERY = "battery"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MiTempPoller(object):
+    """"
+    A class to read data from Mi Temp plant sensors.
+    """
+
+    def __init__(self, mac, backend, cache_timeout=600, retries=3, adapter='hci0'):
+        """
+        Initialize a Mi Temp Poller for the given MAC address.
+        """
+
+        self._mac = mac
+        self._bt_interface = BluetoothInterface(backend, adapter)
+        self._cache = None
+        self._cache_timeout = timedelta(seconds=cache_timeout)
+        self._last_read = None
+        self._fw_last_read = None
+        self.retries = retries
+        self.ble_timeout = 10
+        self.lock = Lock()
+        self._firmware_version = None
+        self.battery = None
+
+    def name(self):
+        """Return the name of the sensor."""
+        with self._bt_interface.connect(self._mac) as connection:
+            name = connection.read_handle(_HANDLE_READ_NAME)  # pylint: disable=no-member
+
+        if not name:
+            raise BluetoothBackendException("Could not read data from Mi Temp sensor %s" % self._mac)
+        return ''.join(chr(n) for n in name)
+
+    def fill_cache(self):
+        """Fill the cache with new data from the sensor."""
+        _LOGGER.debug('Filling cache with new sensor data.')
+        try:
+            self.firmware_version()
+        except BluetoothBackendException:
+            # If a sensor doesn't work, wait 5 minutes before retrying
+            self._last_read = datetime.now() - self._cache_timeout + \
+                timedelta(seconds=300)
+            raise
+
+        with self._bt_interface.connect(self._mac) as connection:
+            try:
+                connection.wait_for_notification(_HANDLE_READ_WRITE_SENSOR_DATA, self, 10)
+                # If a sensor doesn't work, wait 5 minutes before retrying
+            except BluetoothBackendException:
+                self._last_read = datetime.now() - self._cache_timeout + \
+                    timedelta(seconds=300)
+                return
+
+    def battery_level(self):
+        """Return the battery level.
+
+        The battery level is updated when reading the firmware version. This
+        is done only once every 24h
+        """
+        self.firmware_version()
+        return self.battery
+
+    def firmware_version(self):
+        """Return the firmware version."""
+        if (self._firmware_version is None) or \
+                (datetime.now() - timedelta(hours=24) > self._fw_last_read):
+            self._fw_last_read = datetime.now()
+            with self._bt_interface.connect(self._mac) as connection:
+                res_firmware = connection.read_handle(_HANDLE_READ_FIRMWARE_VERSION)  # pylint: disable=no-member
+                _LOGGER.debug('Received result for handle %s: %s',
+                              _HANDLE_READ_FIRMWARE_VERSION, res_firmware)
+                res_battery = connection.read_handle(_HANDLE_READ_BATTERY_LEVEL)  # pylint: disable=no-member
+                _LOGGER.debug('Received result for handle %s: %d',
+                              _HANDLE_READ_BATTERY_LEVEL, res_battery)
+
+            if res_firmware is None:
+                self._firmware_version = None
+            else:
+                self._firmware_version = res_firmware.decode("utf-8")
+
+            if res_battery is None:
+                self.battery = 0
+            else:
+                self.battery = int(ord(res_battery))
+        return self._firmware_version
+
+    def parameter_value(self, parameter, read_cached=True):
+        """Return a value of one of the monitored paramaters.
+
+        This method will try to retrieve the data from cache and only
+        request it by bluetooth if no cached value is stored or the cache is
+        expired.
+        This behaviour can be overwritten by the "read_cached" parameter.
+        """
+        # Special handling for battery attribute
+        if parameter == MI_BATTERY:
+            return self.battery_level()
+
+        # Use the lock to make sure the cache isn't updated multiple times
+        with self.lock:
+            if (read_cached is False) or \
+                    (self._last_read is None) or \
+                    (datetime.now() - self._cache_timeout > self._last_read):
+                self.fill_cache()
+            else:
+                _LOGGER.debug("Using cache (%s < %s)",
+                              datetime.now() - self._last_read,
+                              self._cache_timeout)
+
+        if self.cache_available():
+            return self._parse_data()[parameter]
+        else:
+            raise BluetoothBackendException("Could not read data from Mi Temp sensor %s" % self._mac)
+
+    def _check_data(self):
+        """Ensure that the data in the cache is valid.
+
+        If it's invalid, the cache is wiped.
+        """
+        if not self.cache_available():
+            return
+
+        parsed = self._parse_data()
+        _LOGGER.debug('Received new data from sensor: Temp=%.1f, Humidity=%.1f',
+                      parsed[MI_TEMPERATURE], parsed[MI_HUMIDITY])
+
+        if parsed[MI_HUMIDITY] > 100:  # humidity over 100 procent
+            self.clear_cache()
+            return
+
+        if parsed[MI_TEMPERATURE] == 0:  # humidity over 100 procent
+            self.clear_cache()
+            return
+
+    def clear_cache(self):
+        """Manually force the cache to be cleared."""
+        self._cache = None
+        self._last_read = None
+
+    def cache_available(self):
+        """Check if there is data in the cache."""
+        return self._cache is not None
+
+    def _parse_data(self):
+        """Parses the byte array returned by the sensor.
+
+        The sensor returns 14 bytes in total, a readable text with the
+        temperature and humidity. e.g.:
+
+        54 3d 32 35 2e 36 20 48 3d 32 33 2e 36 00 -> T=25.6 H=23.6
+
+        """
+        data = self._cache
+
+        res = dict()
+        res[MI_HUMIDITY] = float(data[9:13])
+        res[MI_TEMPERATURE] = float(data[2:6])
+        return res
+
+    @staticmethod
+    def _format_bytes(raw_data):
+        """Prettyprint a byte array."""
+        if raw_data is None:
+            return 'None'
+        return ' '.join([format(c, "02x") for c in raw_data]).upper()
+
+    def handleNotification(self, handle, raw_data):
+        """ gets called by the bluepy backend when using wait_for_notification
+        """
+        if raw_data is None:
+            return
+        data = raw_data.decode("utf-8").strip(' \n\t')
+        self._cache = data
+        self._check_data()
+        if self.cache_available():
+            self._last_read = datetime.now()
+        else:
+            # If a sensor doesn't work, wait 5 minutes before retrying
+            self._last_read = datetime.now() - self._cache_timeout + \
+                timedelta(seconds=300)

--- a/test/mitemp_mock_backend.py
+++ b/test/mitemp_mock_backend.py
@@ -1,0 +1,191 @@
+"""Helper functions for unit tests."""
+from miflora.backends import AbstractBackend, BluetoothBackendException
+
+
+_HANDLE_READ_BATTERY_LEVEL = 0x0018
+_HANDLE_READ_FIRMWARE_VERSION = 0x0024
+_HANDLE_READ_NAME = 0x03
+_HANDLE_READ_WRITE_SENSOR_DATA = 0x0010
+
+class MiTempMockBackend(AbstractBackend):
+    """Mockup of a Backend and Sensor.
+
+    The behaviour of this Sensors is based on the knowledge there
+    is so far on the behaviour of the sensor. So if our knowledge
+    is wrong, so is the behaviour of this sensor! Thus is always
+    makes sensor to also test against a real sensor.
+    """
+
+    def __init__(self, adapter='hci0'):
+        super(MiTempMockBackend, self).__init__(adapter)
+        self._version = '00.00.66'
+        self.name = 'MJ_HT_V1'
+        self.battery_level = 0
+        self.temperature = 0.0
+        self.humidity = 0.0
+        self.written_handles = []
+        self.expected_write_handles = set()
+        self.override_read_handles = dict()
+        self.is_available = True
+        self._handle_0x03_raw_set = False
+        self._handle_0x03_raw = None
+        self._handle_0x0010_raw_set = False
+        self._handle_0x0010_raw = None
+        self._handle_0x0018_raw_set = False
+        self._handle_0x0018_raw = None
+        self._handle_0x0024_raw_set = False
+        self._handle_0x0024_raw = None
+
+    def check_backend(self):
+        """This backend is available when the field is set accordingly."""
+        return self.is_available
+
+    def set_version(self, version):
+        """Sets the version number to be returned."""
+        self._version = version
+
+    @property
+    def version(self):
+        """Get the stored version number as string."""
+        return self._version
+
+    def read_handle(self, handle):
+        """Read one of the handles that are implemented."""
+        if handle in self.override_read_handles:
+            return self.override_read_handles[handle]
+        elif handle == _HANDLE_READ_BATTERY_LEVEL:
+            return self._read_battery_level()
+        elif handle == _HANDLE_READ_FIRMWARE_VERSION:
+            return self._read_firmware()
+        elif handle == _HANDLE_READ_NAME:
+            return self._read_name()
+        else:
+            raise ValueError('handle not implemented in mockup')
+
+    def write_handle(self, handle, value):
+        """Writing handles just stores the results in a list."""
+        self.written_handles.append((handle, value))
+        return handle in self.expected_write_handles
+
+    def wait_for_notification(self, handle, delegate, timeout):
+        """Recreate sensor data from the fields of this class."""
+        if self._handle_0x0010_raw_set:
+            delegate.handleNotification(handle, self._handle_0x0010_raw)
+            return
+        result = [ord(c) for c in "T={:.1f} H={:.1f}".format(self.temperature, self.humidity)]
+        delegate.handleNotification(handle, bytes(result))
+
+    def _read_battery_level(self):
+        """Recreate the battery level from the fields of this class."""
+        if self._handle_0x0018_raw_set:
+            return self._handle_0x0018_raw
+        return chr(self.battery_level)
+
+    def _read_firmware(self):
+        """Recreate the firmware from the fields of this class."""
+        if self._handle_0x0024_raw_set:
+            return self._handle_0x0024_raw
+        result = [ord(c) for c in self.version]
+        return bytes(result)
+
+    def _read_name(self):
+        """Convert the name into a byte array and return it."""
+        if self._handle_0x03_raw_set:
+            return self._handle_0x03_raw
+        return [ord(c) for c in self.name]
+
+    @property
+    def handle_0x03_raw(self):
+        """Getter for handle_0x03_raw."""
+        return self._handle_0x03_raw
+
+    @handle_0x03_raw.setter
+    def handle_0x03_raw(self, value):
+        """Setter for handle_0x03_raw.
+
+        This needs a separate flag so that we can also use "None" as return value.
+        """
+        self._handle_0x03_raw_set = True
+        self._handle_0x03_raw = value
+
+    @property
+    def handle_0x0010_raw(self):
+        """Getter for handle_0x10_raw."""
+        return self._handle_0x0010_raw
+
+    @handle_0x0010_raw.setter
+    def handle_0x0010_raw(self, value):
+        """Setter for handle_0x10_raw.
+
+        This needs a separate flag so that we can also use "None" as return value.
+        """
+        self._handle_0x0010_raw_set = True
+        self._handle_0x0010_raw = value
+
+    @property
+    def handle_0x0018_raw(self):
+        """Getter for handle_0x0018_raw."""
+        return self._handle_0x0018_raw
+
+    @handle_0x0018_raw.setter
+    def handle_0x0018_raw(self, value):
+        """Setter for handle_0x0018_raw.
+
+        This needs a separate flag so that we can also use "None" as return value.
+        """
+        self._handle_0x0018_raw_set = True
+        self._handle_0x0018_raw = value
+
+    @property
+    def handle_0x0024_raw(self):
+        """Getter for handle_0x0024_raw."""
+        return self._handle_0x0024_raw
+
+    @handle_0x0024_raw.setter
+    def handle_0x0024_raw(self, value):
+        """Setter for handle_0x0024_raw.
+
+        This needs a separate flag so that we can also use "None" as return value.
+        """
+        self._handle_0x0024_raw_set = True
+        self._handle_0x0024_raw = value
+
+
+class ConnectExceptionBackend(AbstractBackend):
+    """This backend always raises Exceptions."""
+
+    def connect(self, mac):
+        """Raise exception when connecting."""
+        raise BluetoothBackendException('always raising exceptions')
+
+    def disconnect(self):
+        """Disconnect always works"""
+
+    def check_backend(self):
+        """check backend must pass so that we get to the BT communication."""
+        return True
+
+
+class RWExceptionBackend(AbstractBackend):
+    """This backend always raises Exceptions."""
+
+    def connect(self, mac):
+        """Connect always works"""
+
+    def disconnect(self):
+        """Disconnect always works"""
+
+    def check_backend(self):
+        """check backend must pass so that we get to the BT communication."""
+        return True
+
+    def read_handle(self, _):
+        """Reading always fails."""
+        raise BluetoothBackendException('always raising')
+
+    def read_write(self, _, __):  # pylint: disable=no-self-use
+        """Writing always fails."""
+        raise BluetoothBackendException('always raising')
+
+    def wait_for_notification(self, handle, delegate, timeout):
+        raise BluetoothBackendException('always raising')

--- a/test/mitemp_mock_backend.py
+++ b/test/mitemp_mock_backend.py
@@ -7,6 +7,7 @@ _HANDLE_READ_FIRMWARE_VERSION = 0x0024
 _HANDLE_READ_NAME = 0x03
 _HANDLE_READ_WRITE_SENSOR_DATA = 0x0010
 
+
 class MiTempMockBackend(AbstractBackend):
     """Mockup of a Backend and Sensor.
 

--- a/test/unit_tests/test_gatttool.py
+++ b/test/unit_tests/test_gatttool.py
@@ -78,7 +78,7 @@ class TestGatttool(unittest.TestCase):
 
     @mock.patch('miflora.backends.gatttool.Popen')
     @mock.patch('time.sleep', return_value=None)
-    def wait_for_notification(self, time_mock, popen_mock):
+    def test_wait_for_notification(self, time_mock, popen_mock):
         """Test writing to a handle successfully."""
         _configure_popenmock(popen_mock, 'Characteristic value was written successfully')
         backend = GatttoolBackend()

--- a/test/unit_tests/test_gatttool.py
+++ b/test/unit_tests/test_gatttool.py
@@ -78,6 +78,15 @@ class TestGatttool(unittest.TestCase):
 
     @mock.patch('miflora.backends.gatttool.Popen')
     @mock.patch('time.sleep', return_value=None)
+    def wait_for_notification(self, time_mock, popen_mock):
+        """Test writing to a handle successfully."""
+        _configure_popenmock(popen_mock, 'Characteristic value was written successfully')
+        backend = GatttoolBackend()
+        backend.connect(TEST_MAC)
+        self.assertTrue(backend.wait_for_notification(0xFF, None, 10))
+
+    @mock.patch('miflora.backends.gatttool.Popen')
+    @mock.patch('time.sleep', return_value=None)
     def test_write_handle_wrong_handle(self, time_mock, popen_mock):
         """Test writing to a non-writable handle."""
         _configure_popenmock(popen_mock, "Characteristic Write Request failed: Attribute can't be written")

--- a/test/unit_tests/test_mitemp_poller.py
+++ b/test/unit_tests/test_mitemp_poller.py
@@ -1,0 +1,139 @@
+"""Tests for the miflora_poller module."""
+import unittest
+from test.mitemp_mock_backend import MiTempMockBackend, ConnectExceptionBackend, RWExceptionBackend
+
+from miflora import BluetoothBackendException
+from miflora.mitemp_poller import MiTempPoller, MI_TEMPERATURE, MI_HUMIDITY, MI_BATTERY
+
+
+class TestMiTempPoller(unittest.TestCase):
+    """Tests for the MiTempPoller class."""
+
+    # access to protected members is fine in testing
+    # pylint: disable = protected-access
+
+    TEST_MAC = '11:22:33:44:55:66'
+
+    def test_format_bytes(self):
+        """Test conversion of bytes to string."""
+        self.assertEqual('AA BB 00', MiTempPoller._format_bytes([0xAA, 0xBB, 0x00]))
+
+    def test_read_battery(self):
+        """Test reading the battery level."""
+        poller = MiTempPoller(self.TEST_MAC, MiTempMockBackend)
+        backend = self._get_backend(poller)
+        backend.battery_level = 50
+        self.assertEqual(50, poller.battery_level())
+        self.assertEqual(50, poller.parameter_value(MI_BATTERY))
+        self.assertEqual(0, len(backend.written_handles))
+
+    def test_read_version(self):
+        """Test reading the version number."""
+        poller = MiTempPoller(self.TEST_MAC, MiTempMockBackend)
+        backend = self._get_backend(poller)
+        backend.set_version('00.00.11')
+        self.assertEqual('00.00.11', poller.firmware_version())
+        self.assertEqual(0, len(backend.written_handles))
+
+    def test_read_measurements(self):
+        """Test reading data from new sensors.
+
+        Here we expect some data being written to the sensor.
+        """
+        poller = MiTempPoller(self.TEST_MAC, MiTempMockBackend)
+        backend = self._get_backend(poller)
+
+        backend.temperature = 56.7
+
+        self.assertAlmostEqual(backend.temperature, poller.parameter_value(MI_TEMPERATURE), delta=0.11)
+
+    def test_name(self):
+        """Check reading of the sensor name."""
+        poller = MiTempPoller(self.TEST_MAC, MiTempMockBackend)
+        backend = self._get_backend(poller)
+        backend.name = 'my sensor name'
+
+        self.assertEqual(backend.name, poller.name())
+
+    def test_clear_cache(self):
+        """Test with negative temperature."""
+        poller = MiTempPoller(self.TEST_MAC, MiTempMockBackend)
+        backend = self._get_backend(poller)
+
+        self.assertFalse(poller.cache_available())
+        backend.temperature = 1.0
+        self.assertAlmostEqual(1.0, poller.parameter_value(MI_TEMPERATURE), delta=0.01)
+        self.assertTrue(poller.cache_available())
+
+        # data is taken from cache, new value is ignored
+        backend.temperature = 2.0
+        self.assertAlmostEqual(1.0, poller.parameter_value(MI_TEMPERATURE), delta=0.01)
+
+        self.assertTrue(poller.cache_available())
+        poller.clear_cache()
+        self.assertFalse(poller.cache_available())
+
+        backend.temperature = 3.0
+        self.assertAlmostEqual(3.0, poller.parameter_value(MI_TEMPERATURE), delta=0.01)
+        self.assertTrue(poller.cache_available())
+
+    def test_no_answer_data(self):
+        """Sensor returns None for handle 0x35.
+
+        Check that this triggers the right exception.
+        """
+        poller = MiTempPoller(self.TEST_MAC, MiTempMockBackend)
+        backend = self._get_backend(poller)
+        backend.handle_0x0010_raw = None
+        with self.assertRaises(BluetoothBackendException):
+            poller.parameter_value(MI_TEMPERATURE)
+
+    def test_no_answer_name(self):
+        """Sensor returns None for handle 0x03.
+
+        Check that this triggers the right exception.
+        """
+        poller = MiTempPoller(self.TEST_MAC, MiTempMockBackend)
+        backend = self._get_backend(poller)
+        backend.handle_0x03_raw = None
+        with self.assertRaises(BluetoothBackendException):
+            poller.name()
+
+    def test_no_answer_firmware_version(self):
+        """Sensor returns None for handle 0x03.
+
+        Check that this triggers the right exception.
+        """
+        poller = MiTempPoller(self.TEST_MAC, MiTempMockBackend)
+        backend = self._get_backend(poller)
+        backend.handle_0x0024_raw = None
+        self.assertTrue(poller.firmware_version() is None)
+
+    def test_connect_exception(self):
+        """Test reaction when getting a BluetoothBackendException."""
+        poller = MiTempPoller(self.TEST_MAC, ConnectExceptionBackend, retries=0)
+        with self.assertRaises(BluetoothBackendException):
+            poller.firmware_version()
+        with self.assertRaises(BluetoothBackendException):
+            poller.name()
+        with self.assertRaises(BluetoothBackendException):
+            poller.parameter_value(MI_TEMPERATURE)
+        with self.assertRaises(BluetoothBackendException):
+            poller.parameter_value(MI_HUMIDITY)
+
+    def test_rw_exception(self):
+        """Test reaction when getting a BluetoothBackendException."""
+        poller = MiTempPoller(self.TEST_MAC, RWExceptionBackend, retries=0)
+        with self.assertRaises(BluetoothBackendException):
+            poller.firmware_version()
+        with self.assertRaises(BluetoothBackendException):
+            poller.name()
+        with self.assertRaises(BluetoothBackendException):
+            poller.parameter_value(MI_TEMPERATURE)
+        with self.assertRaises(BluetoothBackendException):
+            poller.parameter_value(MI_HUMIDITY)
+
+    @staticmethod
+    def _get_backend(poller):
+        """Get the backend from a MiTempPoller object."""
+        return poller._bt_interface._backend


### PR DESCRIPTION
Support for the recently announced Temp and Humidity Sensor of Xiaomi with Bluetooth and LCD display.
I did not want to duplicate all the back-end code, thus added support for an extra sensor in this package.

To be fully used, it needs a file called `site-packages/homeassistant/components/sensor/mitemp.py` that is just a slightly amended version of the miflora.py, available here: https://gist.github.com/ratcashdev/2060fd95158dacae93a80a92ae7083a4