### PR TITLE
Fixed Travis CI build for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: python
 install: pip install -U tox coveralls
+dist: xenial
 
 matrix:
   fast_finish: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,6 @@ setup(
     keywords='plant sensor bluetooth low-energy ble',
     zip_safe=False,
     install_requires=['btlewrap==0.0.2'],
-    extras_require={'testing': ['pytest']}
+    extras_require={'testing': ['pytest']},
+    include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,16 @@
 """Python package description."""
-import os
 from setuptools import setup, find_packages
 
 
 def readme():
     """Load the readme file."""
-    readme_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.md')
-    listing = os.listdir(os.path.dirname(readme_path))
-    if not os.path.exists(readme_path):
-        raise Exception('Could not find readme file in {}. Listing:\n{}'.format(readme_path, '\n'.join(sorted(listing))))
-    with open(readme_path, 'r') as readme_file:
+    with open('README.md', 'r') as readme_file:
         return readme_file.read()
 
 
 setup(
     name='miflora',
-    version='0.4',
+    version='0.4.1',
     description='Library to read data from Mi Flora sensor',
     long_description=readme(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,10 @@ from setuptools import setup, find_packages
 
 def readme():
     """Load the readme file."""
-    readme_path = os.path.join(os.path.dirname(__file__), 'README.md')
+    readme_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.md')
+    listing = os.listdir(os.path.dirname(readme_path))
+    if not os.path.exists(readme_path):
+        raise Exception('Could not find readme file in {}. Listing:\n{}'.format(readme_path, '\n'.join(sorted(listing))))
     with open(readme_path, 'r') as readme_file:
         return readme_file.read()
 


### PR DESCRIPTION
For weird reasons the build on Travis CI for Python 3.4 started failing.

Solution:
* include README.md in the egg
* upgrade build container to Ubuntu Xenial