### PR TITLE
Bumped version number of btlewrap to 0.0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 bluepy==1.1.4
 pygatt==3.2.0
-btlewrap==0.0.3
+btlewrap>=0.0.4

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     packages=find_packages(),
     keywords='plant sensor bluetooth low-energy ble',
     zip_safe=False,
-    install_requires=['btlewrap==0.0.3'],
+    install_requires=['btlewrap>=0.0.4'],
     extras_require={'testing': ['pytest']},
     include_package_data=True,
 )


### PR DESCRIPTION
Incremented version number in dependency to miflora to fix this bug:
https://github.com/zewelor/bt-mqtt-gateway/issues/39
