### PR TITLE
Fixes #144 by removing `typing` dep for py3.5+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 bluepy==1.3.0
 pygatt==3.2.0
 btlewrap==0.0.9
-typing>=3,<4
+typing>=3,<4; python_version < 3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 bluepy==1.3.0
 pygatt==3.2.0
 btlewrap==0.0.9
-typing>=3,<4; python_version < 3.5


### PR DESCRIPTION
For Python 3.5 and above the `typing` module is integrated in Python so it has no effect. But it seems to break `pip` in certain cases as shown in #144 